### PR TITLE
feat: close the popover on `mousedown` instead of `click`

### DIFF
--- a/src/components/Popover.vue
+++ b/src/components/Popover.vue
@@ -665,7 +665,7 @@ if (typeof document !== 'undefined' && typeof window !== 'undefined') {
       capture: true,
     } : true)
   } else {
-    window.addEventListener('click', handleGlobalClick, true)
+    window.addEventListener('mousedown', handleGlobalClick, true)
   }
 }
 


### PR DESCRIPTION
I needed to change the event, with which the popover component is closed when the user clicks outside. Instead of listening to `click`, with this change it listens to `mousedown` now.

The reason for that is that if you open the popover, then drag the window with the scrollbar, it will only close the popover *after* releasing the scrollbar.