### PR TITLE
fix of "options" unavailable issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,8 @@ const plugin = {
   set enabled (value) {
     state.enabled = value
   },
+
+  options: defaultOptions,
 }
 
 // Auto-install


### PR DESCRIPTION
As can I see property "options" is declared in interface "GlobalVTooltip" `types/index.d.ts`:

```
export interface GlobalVTooltip {
  enabled?: boolean
  options?: Partial<GlobalVTooltipOptions>
}

declare const vToolTip: PluginFunction<Partial<GlobalVTooltipOptions>> & GlobalVTooltip;
export default vToolTip;
```

but is lost in code `src/index.js`:

```
const plugin = {
  install,

  get enabled () {
    return state.enabled
  },

  set enabled (value) {
    state.enabled = value
  }

....

export default plugin
}
```