### PR TITLE
fix: ignore triggers watch before init has been run on mounted

### DIFF
--- a/packages/v-tooltip/src/components/Popper.js
+++ b/packages/v-tooltip/src/components/Popper.js
@@ -291,8 +291,10 @@ export default () => ({
     },
 
     triggers () {
-      this.$_removeEventListeners()
-      this.$_addEventListeners()
+      if (Array.isArray(this.$_events)) {
+        this.$_removeEventListeners()
+        this.$_addEventListeners()
+      }
     },
 
     placement: '$_refreshPopperOptions',


### PR DESCRIPTION
This resolves #817 by having the watch on triggers do nothing if $_events isn't an array, since that means init hasn't been run yet and when it is it will do what's needed.