### PR TITLE
docs: Correct typo in documentation

### DIFF
--- a/packages/docs/src/guide/directive.md
+++ b/packages/docs/src/guide/directive.md
@@ -94,7 +94,7 @@ Use the `triggers` and `shown` options from the [popper component](./component.m
 On mobile, you can disable the tooltips with the `disabled` prop on the `tooltip` theme:
 
 ```javascript
-VTooltip.options.themes.tooltip.disabled = window.innerWidth <= 768
+FloatingVue.options.themes.tooltip.disabled = window.innerWidth <= 768
 ```
 
 You can still override this value, just like you would for any other prop which has a default value in the [configuration](./config.md):


### PR DESCRIPTION
This fixes a typo I stumbled upon, closes https://github.com/Akryum/floating-vue/issues/849