### PR TITLE
Use floating-ui’s autoUpdate to handle updates of positioning

### DIFF
--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -15,8 +15,7 @@
   "module": "dist/floating-vue.es.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@floating-ui/dom": "^0.5.0",
-    "vue-resize": "^2.0.0-alpha.1"
+    "@floating-ui/dom": "^0.5.0"
   },
   "peerDependencies": {
     "vue": "^3.2.0"

--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -15,7 +15,7 @@
   "module": "dist/floating-vue.es.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@floating-ui/dom": "^0.1.10",
+    "@floating-ui/dom": "^0.5.0",
     "vue-resize": "^2.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -6,7 +6,7 @@ import {
   shift,
   flip,
   arrow,
-  getScrollParents,
+  getOverflowAncestors,
   size,
 } from '@floating-ui/dom'
 import { supportsPassive, isIOS } from '../util/env'
@@ -633,7 +633,7 @@ export default () => defineComponent({
         options.middleware.push(size({
           boundary: this.boundary,
           padding: this.overflowPadding,
-          apply: ({ width, height }) => {
+          apply: ({ availableWidth: width, availableHeight: height }) => {
             // Apply and re-compute
             this.$_innerNode.style.maxWidth = width != null ? `${width}px` : null
             this.$_innerNode.style.maxHeight = height != null ? `${height}px` : null
@@ -716,8 +716,8 @@ export default () => defineComponent({
       // Scroll
       if (!this.positioningDisabled) {
         this.$_registerEventListeners([
-          ...getScrollParents(this.$_referenceNode),
-          ...getScrollParents(this.$_popperNode),
+          ...getOverflowAncestors(this.$_referenceNode),
+          ...getOverflowAncestors(this.$_popperNode),
         ], 'scroll', () => {
           this.$_computePosition()
         })

--- a/packages/floating-vue/src/components/PopperContent.vue
+++ b/packages/floating-vue/src/components/PopperContent.vue
@@ -45,11 +45,6 @@
           <div>
             <slot />
           </div>
-
-          <ResizeObserver
-            v-if="handleResize"
-            @notify="$emit('resize', $event)"
-          />
         </template>
       </div>
 
@@ -70,15 +65,10 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import { ResizeObserver } from 'vue-resize'
 import ThemeClass from './ThemeClass'
 
 export default defineComponent({
   name: 'VPopperContent',
-
-  components: {
-    ResizeObserver,
-  },
 
   mixins: [
     ThemeClass(),

--- a/packages/floating-vue/src/components/PopperWrapper.vue
+++ b/packages/floating-vue/src/components/PopperWrapper.vue
@@ -10,7 +10,6 @@
       show,
       hide,
       handleResize,
-      onResize,
       classes,
       result,
       attrs,
@@ -52,7 +51,6 @@
         :classes="classes"
         :result="result"
         @hide="hide"
-        @resize="onResize"
       >
         <slot
           name="popper"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,12 +1294,24 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.3.1.tgz#3dde0ad0724d4b730567c92f49f0950910e18871"
   integrity sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g==
 
+"@floating-ui/core@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.0.tgz#f2442168d65c22daeb48cfb730cbc3a29a846ac7"
+  integrity sha512-W7+i5Suhhvv97WDTW//KqUA43f/2a4abprM1rWqtLM9lIlJ29tbFI8h232SvqunXon0WmKNEKVjbOsgBhTnbLw==
+
 "@floating-ui/dom@^0.1.10":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.1.10.tgz#ce304136a52c71ef157826d2ebf52d68fa2deed5"
   integrity sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==
   dependencies:
     "@floating-ui/core" "^0.3.0"
+
+"@floating-ui/dom@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.0.tgz#e4efd9e609ff3ee6778fbe4273930d6d1c220f2e"
+  integrity sha512-PS75dnMg4GdWjDFOiOs15cDzYJpukRNHqQn0ugrBlsrpk2n+y8bwZ24XrsdLSL7kxshmxxr2nTNycLnmRIvV7g==
+  dependencies:
+    "@floating-ui/core" "^0.7.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -7665,6 +7677,14 @@ floating-vue@^1.0.0-beta.15:
   dependencies:
     "@floating-ui/dom" "^0.1.10"
     vue-resize "^1.0.0"
+
+floating-vue@^2.0.0-beta.16:
+  version "2.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/floating-vue/-/floating-vue-2.0.0-beta.16.tgz#511d2eca106e67da6ccb4e85bb89c86b96297cbd"
+  integrity sha512-MoVA9pLGMVkuyG9cvlzpSB9//HGynbWnkLr0cxDgnEWORL98kuSa2ph/bcq7sDGNM3l0/3v6HYSqhBMBp9F3/A==
+  dependencies:
+    "@floating-ui/dom" "^0.1.10"
+    vue-resize "^2.0.0-alpha.1"
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
This PR not only updates the `@floating-ui/dom` dependency to the most recent version (0.5.0) to fix some issues, but also uses the `autoUpdate` function available since version 0.3.0 to update the popper and arrow positions.
This means the `vue-resize` dependency and component are no longer required. To keep compatibility, the `resize` event of the popper component is now emitted after updating the position, when requested by autoUpdate.