### PR TITLE
Performance fix: prevent unnecessary re-rendering

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -11,6 +11,7 @@
     "core-js": "^3.8.1",
     "floating-vue": "^1.0.0-beta.18",
     "screenfull": "^4.2.0",
+    "tiptap": "^1.32.2",
     "vue": "^2.6.10",
     "vue-router": "^3.0.1"
   },

--- a/packages/demo/src/PageHome.vue
+++ b/packages/demo/src/PageHome.vue
@@ -14,7 +14,6 @@
       <a href="https://github.com/Akryum/v-tooltip/issues">Report an issue</a>
       <a @click="toggleFullscreen">Toggle fullscreen</a>
     </section>
-    <l-rich-text-editor v-model="msg" v-content="msg"/>
 
     <section class="demo">
       <div class="section-content">

--- a/packages/demo/src/PageHome.vue
+++ b/packages/demo/src/PageHome.vue
@@ -14,6 +14,7 @@
       <a href="https://github.com/Akryum/v-tooltip/issues">Report an issue</a>
       <a @click="toggleFullscreen">Toggle fullscreen</a>
     </section>
+    <l-rich-text-editor v-model="msg" v-content="msg"/>
 
     <section class="demo">
       <div class="section-content">

--- a/packages/demo/src/Performance.vue
+++ b/packages/demo/src/Performance.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="page-home page">
+      <rich-text-editor v-model="content" :content="content"></rich-text-editor>
+      <div
+            v-for="k in Array.from(Array(1000).keys())"
+            :key="k"
+            v-tooltip.top="`static content, no need re-render`"
+            for="notAnonymous"
+        >
+            Hover Me
+        </div>
+  </div>
+</template>
+
+<script>
+import RichTextEditor from "./RichTextEditor.vue";
+
+
+export default {
+  name: 'Home',
+  components: {
+    RichTextEditor
+  },
+
+  data () {
+    return {
+      msg: 'This is a button.',
+      content: 'default <strong>content</strong>'
+    }
+  },
+
+  methods: {
+    
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.close {
+  text-align: center;
+  margin-top: 12px;
+}
+</style>

--- a/packages/demo/src/RichTextEditor.vue
+++ b/packages/demo/src/RichTextEditor.vue
@@ -1,0 +1,70 @@
+<template>
+    <div
+        :id="`editor-${uniqId}`"
+        :ref="`editor-${uniqId}`"
+        class="editor"
+    >
+        <editor-content :editor="editor" />
+
+    </div>
+</template>
+
+<script>
+import { Editor, EditorContent } from "tiptap";
+
+
+
+export default {
+    components: {
+        EditorContent,
+    },
+    props: {
+        content: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            editor: null,
+            
+            uniqId: Math.random().toString(36),
+            targetStyle: {},
+            
+        };
+    },
+    computed: {
+       
+    },
+    watch: {
+        content(c) {
+            if (this.editor && !this.editorChange) {
+                this.editor.setContent(c, true);
+            }
+            this.editorChange = false;
+        },
+    },
+    mounted() {
+        const extensions = [
+            
+        ];
+        
+        this.editor = new Editor({
+            onUpdate: ({ getHTML }) => {
+                this.editorChange = true;
+                this.$emit("input", getHTML());
+            },
+            onBlur: ({ event }) => {
+                this.$emit("blur", event);
+            },
+            content: this.content,
+            extensions,
+        });
+    },
+    beforeDestroy() {
+        this.editor?.destroy();
+    },
+    methods: {
+    },
+};
+</script>

--- a/packages/demo/src/main.js
+++ b/packages/demo/src/main.js
@@ -6,6 +6,7 @@ import './style/index.css'
 import App from './App.vue'
 import PageHome from './PageHome.vue'
 import PageInstall from './PageInstall.vue'
+import Performance from './Performance.vue';
 
 Vue.use(FloatingVue, {
   disposeTimeout: 5000,
@@ -42,6 +43,7 @@ Vue.use(VueRouter)
 const router = new VueRouter({
   routes: [
     { path: '/', name: 'home', component: PageHome },
+    { path: '/perf', name: 'Perf', component: Performance },
     { path: '/install', name: 'install', component: PageInstall },
     { path: '/table', name: 'table', component: () => import('./PageTable.vue') },
     { path: '/hover-dropdown', name: 'hover-dropdown', component: () => import('./PageHoverDropdown.vue') },

--- a/packages/floating-vue/src/directives/v-tooltip.ts
+++ b/packages/floating-vue/src/directives/v-tooltip.ts
@@ -52,7 +52,7 @@ export function createTooltip (el, value, modifiers) {
         options,
       }
     },
-    render (h) { 
+    render (h) {
       const {
         theme,
         html,
@@ -60,6 +60,7 @@ export function createTooltip (el, value, modifiers) {
         loadingContent,
         ...otherOptions
       } = this.options
+
       return h(TooltipDirective, {
         props: {
           theme,

--- a/packages/floating-vue/src/directives/v-tooltip.ts
+++ b/packages/floating-vue/src/directives/v-tooltip.ts
@@ -52,7 +52,7 @@ export function createTooltip (el, value, modifiers) {
         options,
       }
     },
-    render (h) {
+    render (h) { 
       const {
         theme,
         html,
@@ -60,7 +60,6 @@ export function createTooltip (el, value, modifiers) {
         loadingContent,
         ...otherOptions
       } = this.options
-
       return h(TooltipDirective, {
         props: {
           theme,
@@ -122,9 +121,15 @@ export function bind (el, { value, oldValue, modifiers }) {
   }
 }
 
+export function update (el, { value, oldValue, modifiers }) {
+  if (value !== oldValue) { // avoid unnecessary updates
+    bind(el, {value, oldValue, modifiers})
+  }
+}
+
 export default {
   bind,
-  update: bind,
+  update,
   unbind (el) {
     destroyTooltip(el)
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10490,6 +10490,11 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
+orderedmap@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-2.0.0.tgz#12ff5ef6ea9d12d6430b80c701b35475e1c9ff34"
+  integrity sha512-buf4PoAMlh45b8a8gsGy/X6w279TSqkyAS0C0wdTSJwFSU+ljQFJON5I8NfjLHoCXwpSROIo2wr0g33T+kQshQ==
+
 original@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/original/-/original-1.0.2.tgz#e442a61cffe1c5fd20a65f3261c26663b303f25f"
@@ -11461,6 +11466,101 @@ promzard@^0.3.0:
   integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
   dependencies:
     read "1"
+
+prosemirror-commands@^1.1.4:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-commands/-/prosemirror-commands-1.3.0.tgz#361b2e2b2a347ce7453386459f97c3f549a1113b"
+  integrity sha512-BwBbZ5OAScPcm0x7H8SPbqjuEJnCU2RJT9LDyOiiIl/3NbL1nJZI4SFNHwU2e/tRr2Xe7JsptpzseqvZvToLBQ==
+  dependencies:
+    prosemirror-model "^1.0.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.0.0"
+
+prosemirror-dropcursor@^1.3.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-dropcursor/-/prosemirror-dropcursor-1.5.0.tgz#edbc61d6f71f9f924130eec8e85b0861357957c9"
+  integrity sha512-vy7i77ddKyXlu8kKBB3nlxLBnsWyKUmQIPB5x8RkYNh01QNp/qqGmdd5yZefJs0s3rtv5r7Izfu2qbtr+tYAMQ==
+  dependencies:
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.1.0"
+    prosemirror-view "^1.1.0"
+
+prosemirror-gapcursor@^1.1.5:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.1.tgz#8cfd874592e4504d63720e14ed680c7866e64554"
+  integrity sha512-GKTeE7ZoMsx5uVfc51/ouwMFPq0o8YrZ7Hx4jTF4EeGbXxBveUV8CGv46mSHuBBeXGmvu50guoV2kSnOeZZnUA==
+  dependencies:
+    prosemirror-keymap "^1.0.0"
+    prosemirror-model "^1.0.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-view "^1.0.0"
+
+prosemirror-inputrules@^1.1.2, prosemirror-inputrules@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-inputrules/-/prosemirror-inputrules-1.2.0.tgz#476dde2dc244050b3aca00cf58a82adfad6749e7"
+  integrity sha512-eAW/M/NTSSzpCOxfR8Abw6OagdG0MiDAiWHQMQveIsZtoKVYzm0AflSPq/ymqJd56/Su1YPbwy9lM13wgHOFmQ==
+  dependencies:
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.0.0"
+
+prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.1.2, prosemirror-keymap@^1.1.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-keymap/-/prosemirror-keymap-1.2.0.tgz#d5cc9da9b712020690a994b50b92a0e448a60bf5"
+  integrity sha512-TdSfu+YyLDd54ufN/ZeD1VtBRYpgZnTPnnbY+4R08DDgs84KrIPEPbJL8t1Lm2dkljFx6xeBE26YWH3aIzkPKg==
+  dependencies:
+    prosemirror-state "^1.0.0"
+    w3c-keyname "^2.2.0"
+
+prosemirror-model@^1.0.0, prosemirror-model@^1.13.1, prosemirror-model@^1.16.0, prosemirror-model@^1.8.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.18.1.tgz#1d5d6b6de7b983ee67a479dc607165fdef3935bd"
+  integrity sha512-IxSVBKAEMjD7s3n8cgtwMlxAXZrC7Mlag7zYsAKDndAqnDScvSmp/UdnRTV/B33lTCVU3CCm7dyAn/rVVD0mcw==
+  dependencies:
+    orderedmap "^2.0.0"
+
+prosemirror-schema-list@^1.1.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.2.0.tgz#1932268593a7396c0ac168cbe31f28187406ce24"
+  integrity sha512-8PT/9xOx1HHdC7fDNNfhQ50Z8Mzu7nKyA1KCDltSpcZVZIbB0k7KtsHrnXyuIhbLlScoymBiLZ00c5MH6wdFsA==
+  dependencies:
+    prosemirror-model "^1.0.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.0.0"
+
+prosemirror-state@^1.0.0, prosemirror-state@^1.3.1, prosemirror-state@^1.3.3:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.4.1.tgz#f6e26c7b6a7e11206176689eb6ebbf91870953e1"
+  integrity sha512-U/LBDW2gNmVa07sz/D229XigSdDQ5CLFwVB1Vb32MJbAHHhWe/6pOc721faI17tqw4pZ49i1xfY/jEZ9tbIhPg==
+  dependencies:
+    prosemirror-model "^1.0.0"
+    prosemirror-transform "^1.0.0"
+
+prosemirror-tables@^1.1.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.2.2.tgz#92e2a6f568184e9d3bc9bb20ade91f9fc72ce560"
+  integrity sha512-dKIuvsNMNnKjR6KNEdbeOneRuio/OyYUyfhlcnI4YQjXNnsiwE3xDAM7NzbJ/HFHM6keNnoZYhTqczZaULVANg==
+  dependencies:
+    prosemirror-keymap "^1.1.2"
+    prosemirror-model "^1.8.1"
+    prosemirror-state "^1.3.1"
+    prosemirror-transform "^1.2.1"
+    prosemirror-view "^1.13.3"
+
+prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transform@^1.2.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.6.0.tgz#8162dbfaf124f9253a7ab28605a9460411a96a53"
+  integrity sha512-MAp7AjsjEGEqQY0sSMufNIUuEyB1ZR9Fqlm8dTwwWwpEJRv/plsKjWXBbx52q3Ml8MtaMcd7ic14zAHVB3WaMw==
+  dependencies:
+    prosemirror-model "^1.0.0"
+
+prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.16.5:
+  version "1.26.5"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.26.5.tgz#65cb890d0971e94e0cbc09fdb0c5320cd474bc6f"
+  integrity sha512-SO+AX6WwdbJZHVvuloXI0qfO+YJAnZAat8qrYwfiqTQwL/FewLUnr0m3EXZ6a60hQs8/Q/lzeJXiFR/dOPaaKQ==
+  dependencies:
+    prosemirror-model "^1.16.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.1.0"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -13363,6 +13463,44 @@ tinypool@^0.0.5:
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.0.5.tgz#59db30019a61c2b9a3f8c9fe893c19e7573b9de3"
   integrity sha512-5fUjvd0Dcr2a4b3gSAtg58cE0bDX9tc4zsRWEVGxhHUSN1DhITtRK9myC9wFzaZ+a/pP3bJaGIHXBqlrj6XgZg==
 
+tiptap-commands@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/tiptap-commands/-/tiptap-commands-1.17.1.tgz#a8974a26d87db57b2fd4fc56a552520c69e43a4a"
+  integrity sha512-CyGvMD/c6fNer5LThWGtrVMXHAqHn93ivGQpqJ58x3HNZFuoIiF9QTWXAiWbY/4QrG0ANYHKCSe9n5afickTqw==
+  dependencies:
+    prosemirror-commands "^1.1.4"
+    prosemirror-inputrules "^1.1.2"
+    prosemirror-model "^1.13.1"
+    prosemirror-schema-list "^1.1.4"
+    prosemirror-state "^1.3.3"
+    prosemirror-tables "^1.1.1"
+    tiptap-utils "^1.13.1"
+
+tiptap-utils@^1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/tiptap-utils/-/tiptap-utils-1.13.1.tgz#f2150ded432465d66aa03a5ab333803415cddd20"
+  integrity sha512-RoCvMfkdu7fp9u7nsRr1OgsYU8RFjoHKHEKpx075rJ9X0t+j5Vxah9n6QzTTr4yjvcavq22WO2flFacm36zYtA==
+  dependencies:
+    prosemirror-model "^1.13.1"
+    prosemirror-state "^1.3.3"
+    prosemirror-tables "^1.1.1"
+
+tiptap@^1.32.2:
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/tiptap/-/tiptap-1.32.2.tgz#cd6259e853652bfc6860758ff44ebb695d5edd1c"
+  integrity sha512-5IwVj8nGo8y5V3jbdtoEd7xNUsi8Q0N6WV2Nfs70olqz3fldXkiImBrDhZJ4Anx8vhyP6PIBttrg0prFVmwIvw==
+  dependencies:
+    prosemirror-commands "^1.1.4"
+    prosemirror-dropcursor "^1.3.2"
+    prosemirror-gapcursor "^1.1.5"
+    prosemirror-inputrules "^1.1.3"
+    prosemirror-keymap "^1.1.4"
+    prosemirror-model "^1.13.1"
+    prosemirror-state "^1.3.3"
+    prosemirror-view "^1.16.5"
+    tiptap-commands "^1.17.1"
+    tiptap-utils "^1.13.1"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -14113,6 +14251,11 @@ vuepress@^1.8.0:
     envinfo "^7.2.0"
     opencollective-postinstall "^2.0.2"
     update-notifier "^4.0.0"
+
+w3c-keyname@^2.2.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.4.tgz#4ade6916f6290224cdbd1db8ac49eab03d0eef6b"
+  integrity sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.8"


### PR DESCRIPTION
We are having an issue with unnecessary re-rendering for every user input on our tiptap rich-text-editor. 

The typing is super laggy and unresponsive when there are many tooltips on the same page.
Because ALL tooltips are re-rendered on every update/keypress.

I have a tests page: `Performance`, which contains one rich-text-editor and 1000 tooltips, simply 

change this line
https://github.com/Akryum/floating-vue/compare/vue2...rustjson:floating-vue:vue2?diff=split#diff-57103f054b23f6ac8c4a70f7b1ac4d9219b5c2693a75a05903b3967f9d57c6aaR132

to the old version: `update: bind` to reproduce the problem


Some additional information from vue2's document:

https://v2.vuejs.org/v2/guide/custom-directive.html#Hook-Functions

> update: called after the containing component’s VNode has updated, but possibly before its children have updated. The directive’s value may or may not have changed, **but you can skip unnecessary updates by comparing the binding’s current and old values** (see below on hook arguments).

