### PR TITLE
docs: typo

### DIFF
--- a/packages/docs/src/guide/css.md
+++ b/packages/docs/src/guide/css.md
@@ -195,7 +195,7 @@ Full example style:
 
 ## Advanced transitions
 
-The `popper` lement also has dynamic classes working similarly to the Vue transition system:
+The `popper` element also has dynamic classes working similarly to the Vue transition system:
 
 - `v-popper__popper--show-from`: (for advanced transition) initial style when shown.
 - `v-popper__popper--show-to`: (for advanced transition) final style when shown.


### PR DESCRIPTION
I fix typo in [CSS guide](https://floating-vue.starpad.dev/guide/css.html#advanced-transitions).