### PR TITLE
build: exclude sources from published package

### DIFF
--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -14,6 +14,9 @@
   "main": "dist/floating-vue.umd.js",
   "module": "dist/floating-vue.es.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@floating-ui/dom": "^0.1.10",
     "vue-resize": "^2.0.0-alpha.1"


### PR DESCRIPTION
Removes unnecessary files from published package.

The latest `2.0.0-beta.20` includes sources, test files and configuration files: https://unpkg.com/browse/floating-vue@2.0.0-beta.20/

<details>
  <summary>Before</summary>

```sh
$ npm pack --dry-run

npm notice 📦  floating-vue@2.0.0-beta.20
npm notice === Tarball Contents === 
npm notice 1.3kB  .eslintrc.js                             
npm notice 1.1kB  LICENSE                                  
npm notice 867B   README.md                                
npm notice 211B   babel.config.js                          
npm notice 714B   dist/components/Dropdown.vue.d.ts        
npm notice 714B   dist/components/Menu.vue.d.ts            
npm notice 11.2kB dist/components/Popper.d.ts              
npm notice 12.4kB dist/components/Popper.vue.d.ts          
npm notice 1.4kB  dist/components/PopperContent.vue.d.ts   
npm notice 223B   dist/components/PopperMethods.d.ts       
npm notice 740B   dist/components/PopperWrapper.vue.d.ts   
npm notice 128B   dist/components/ThemeClass.d.ts          
npm notice 714B   dist/components/Tooltip.vue.d.ts         
npm notice 892B   dist/components/TooltipDirective.vue.d.ts
npm notice 391B   dist/config.d.ts                         
npm notice 331B   dist/directives/v-close-popper.d.ts      
npm notice 761B   dist/directives/v-tooltip.d.ts           
npm notice 11B    dist/directives/v-tooltip.spec.d.ts      
npm notice 55.5kB dist/floating-vue.es.js                  
npm notice 31.6kB dist/floating-vue.umd.js                 
npm notice 12.6kB dist/index.d.ts                          
npm notice 4.3kB  dist/style.css                           
npm notice 58B    dist/util/assign-deep.d.ts               
npm notice 80B    dist/util/env.d.ts                       
npm notice 236B   dist/util/events.d.ts                    
npm notice 55B    dist/util/frame.d.ts                     
npm notice 70B    dist/util/lang.d.ts                      
npm notice 198B   dist/util/popper.d.ts                    
npm notice 11.5kB logo.png                                 
npm notice 8.4kB  logo.svg                                 
npm notice 815B   nuxt.mjs                                 
npm notice 2.0kB  package.json                             
npm notice 589B   src/components/Dropdown.vue              
npm notice 213B   src/components/Menu.vue                  
npm notice 31.8kB src/components/Popper.ts                 
npm notice 290B   src/components/Popper.vue                
npm notice 6.6kB  src/components/PopperContent.vue         
npm notice 361B   src/components/PopperMethods.ts          
npm notice 1.7kB  src/components/PopperWrapper.vue         
npm notice 191B   src/components/ThemeClass.ts             
npm notice 467B   src/components/Tooltip.vue               
npm notice 3.3kB  src/components/TooltipDirective.vue      
npm notice 3.7kB  src/config.ts                            
npm notice 2.1kB  src/directives/v-close-popper.ts         
npm notice 750B   src/directives/v-tooltip.spec.ts         
npm notice 3.4kB  src/directives/v-tooltip.ts              
npm notice 30B    src/global-shim.d.ts                     
npm notice 2.2kB  src/index.ts                             
npm notice 275B   src/util/assign-deep.ts                  
npm notice 525B   src/util/env.ts                          
npm notice 230B   src/util/events.ts                       
npm notice 136B   src/util/frame.ts                        
npm notice 139B   src/util/lang.ts                         
npm notice 313B   src/util/popper.ts                       
npm notice 98B    src/vue-shim.d.ts                        
npm notice 420B   tsconfig.json                            
npm notice 649B   vite.config.ts                           
```

</details>

After:

```sh
$ npm pack --dry-run

npm notice 📦  floating-vue@2.0.0-beta.20
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                                  
npm notice 867B   README.md                                
npm notice 714B   dist/components/Dropdown.vue.d.ts        
npm notice 714B   dist/components/Menu.vue.d.ts            
npm notice 11.2kB dist/components/Popper.d.ts              
npm notice 12.4kB dist/components/Popper.vue.d.ts          
npm notice 1.4kB  dist/components/PopperContent.vue.d.ts   
npm notice 223B   dist/components/PopperMethods.d.ts       
npm notice 740B   dist/components/PopperWrapper.vue.d.ts   
npm notice 128B   dist/components/ThemeClass.d.ts          
npm notice 714B   dist/components/Tooltip.vue.d.ts         
npm notice 892B   dist/components/TooltipDirective.vue.d.ts
npm notice 391B   dist/config.d.ts                         
npm notice 331B   dist/directives/v-close-popper.d.ts      
npm notice 761B   dist/directives/v-tooltip.d.ts           
npm notice 11B    dist/directives/v-tooltip.spec.d.ts      
npm notice 55.5kB dist/floating-vue.es.js                  
npm notice 31.6kB dist/floating-vue.umd.js                 
npm notice 12.6kB dist/index.d.ts                          
npm notice 4.3kB  dist/style.css                           
npm notice 58B    dist/util/assign-deep.d.ts               
npm notice 80B    dist/util/env.d.ts                       
npm notice 236B   dist/util/events.d.ts                    
npm notice 55B    dist/util/frame.d.ts                     
npm notice 70B    dist/util/lang.d.ts                      
npm notice 198B   dist/util/popper.d.ts                    
npm notice 2.1kB  package.json              
```
