### PR TITLE
docs: update Nuxt config

### DIFF
--- a/packages/docs/src/guide/installation.md
+++ b/packages/docs/src/guide/installation.md
@@ -164,10 +164,8 @@ yarn add floating-vue
 Add the `floating-vue/nuxt` module to your Nuxt config file:
 
 ```js
-import { defineNuxtConfig } from 'nuxt3'
-
 export default defineNuxtConfig({
-  buildModules: [
+  modules: [
     'floating-vue/nuxt',
   ],
 })


### PR DESCRIPTION
- `buildModules` is now `modules`
- `defineNuxtConfig` no longer need to be imported
- package name should be `nuxt` instead of `nuxt3` now.