### PR TITLE
fix: fix vue/compat warning - specify deep option on array watchers

### DIFF
--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -374,7 +374,10 @@ export default () => defineComponent({
       'triggers',
       'positioningDisabled',
     ].reduce((acc, prop) => {
-      acc[prop] = '$_refreshListeners'
+      acc[prop] = {
+        handler: '$_refreshListeners',
+        deep: true,
+      };
       return acc
     }, {}),
 
@@ -391,7 +394,10 @@ export default () => defineComponent({
       'shiftCrossAxis',
       'flip',
     ].reduce((acc, prop) => {
-      acc[prop] = '$_computePosition'
+      acc[prop] = {
+        handler: '$_computePosition',
+        deep: true,
+      };
       return acc
     }, {}),
   },

--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -377,7 +377,7 @@ export default () => defineComponent({
       acc[prop] = {
         handler: '$_refreshListeners',
         deep: true,
-      };
+      }
       return acc
     }, {}),
 
@@ -397,7 +397,7 @@ export default () => defineComponent({
       acc[prop] = {
         handler: '$_computePosition',
         deep: true,
-      };
+      }
       return acc
     }, {}),
   },


### PR DESCRIPTION
Fixes #962 