### PR TITLE
fix: might miss content clicks inside PopperContent

### DIFF
--- a/packages/floating-vue/src/components/PopperContent.vue
+++ b/packages/floating-vue/src/components/PopperContent.vue
@@ -124,7 +124,6 @@ export default defineComponent({
   visibility: hidden;
   opacity: 0;
   transition: opacity .15s, visibility .15s;
-  pointer-events: none;
 }
 
 .v-popper__popper.v-popper__popper--shown {


### PR DESCRIPTION
While using [elk](https://elk.zone/), I found the following button inside the hover card has changes failing to response to mouse clicks.

I made a video screenshot below:

https://github.com/Akryum/floating-vue/assets/3401641/046f4a26-2ab6-4b8f-8113-0adbecbe27a2

And discovered **remove the style `ponter-event: none` can ensure that the click takes effect.** 

Since the `visibility: hidden` already made sure that the element won't response to click event, I guess `pointer-event: none` is no longer needed here.