### PR TITLE
docs: Fixed spelling mistake in migration v2 docs

### DIFF
--- a/docs/migration/migration-from-v2.md
+++ b/docs/migration/migration-from-v2.md
@@ -21,7 +21,7 @@ floating-vue is a complete rewrite compared to v-tooltip. This migration guide w
 
 ### Floating UI
 
-The positionning library has changed from `popperjs` to [`floating-ui`](https://floating-ui.com/) which is the spiritual successor.
+The positioning library has changed from `popperjs` to [`floating-ui`](https://floating-ui.com/) which is the spiritual successor.
 
 ### Global configuration
 


### PR DESCRIPTION
This PR fixes a spelling mistake in the docs. The word "positionning " has been corrected to "positioning " in the [migration-from-v2.md file](../blob/main/docs/migration/migration-from-v2.md#floating-ui).

