### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/packages/floating-vue/nuxt.mjs
+++ b/packages/floating-vue/nuxt.mjs
@@ -8,7 +8,7 @@ export default async function (_, _nuxt) {
   addPluginTemplate({
     filename: 'floating-vue.mjs',
     getContents: () => `
-      import { defineNuxtPlugin } from '#app'
+      import { defineNuxtPlugin } from '#imports'
       import FloatingVue from 'floating-vue'
       
       export default defineNuxtPlugin((nuxtApp) => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.