### PR TITLE
fix: fix v-close-popper to function on mousedown

### DIFF
--- a/packages/floating-vue/src/directives/v-close-popper.ts
+++ b/packages/floating-vue/src/directives/v-close-popper.ts
@@ -1,7 +1,7 @@
 import { supportsPassive } from '../util/env'
 
 function addListeners (el) {
-  el.addEventListener('click', onClick)
+  el.addEventListener('mousedown', onMouseDown)
   el.addEventListener('touchstart', onTouchStart, supportsPassive
     ? {
       passive: true,
@@ -10,13 +10,13 @@ function addListeners (el) {
 }
 
 function removeListeners (el) {
-  el.removeEventListener('click', onClick)
+  el.removeEventListener('mousedown', onMouseDown)
   el.removeEventListener('touchstart', onTouchStart)
   el.removeEventListener('touchend', onTouchEnd)
   el.removeEventListener('touchcancel', onTouchCancel)
 }
 
-function onClick (event) {
+function onMouseDown (event) {
   const el = event.currentTarget
   event.closePopover = !el.$_vclosepopover_touch
   event.closeAllPopover = el.$_closePopoverModifiers && !!el.$_closePopoverModifiers.all


### PR DESCRIPTION
This PR fixes an issue where the `v-close-popper` directive wouldn't work after v5.1.