### PR TITLE
Performance issue due to adding popper classes to body on page with large number of DOM nodes

### DIFF
--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -207,6 +207,11 @@ const createPopper = () => defineComponent({
       default: defaultPropFactory('computeTransformOrigin'),
     },
 
+    addPopperClassesToBody: {
+      type: Boolean,
+      default: defaultPropFactory('addPopperClassesToBody'),
+    },
+
     /**
      * @deprecated
      */
@@ -773,10 +778,15 @@ const createPopper = () => defineComponent({
       }
 
       shownPoppers.push(this)
-      document.body.classList.add('v-popper--some-open')
+      if (this.addPopperClassesToBody) {
+        document.body.classList.add('v-popper--some-open')
+      }
+
       for (const theme of getAllParentThemes(this.theme)) {
         getShownPoppersByTheme(theme).push(this)
-        document.body.classList.add(`v-popper--some-open--${theme}`)
+        if (this.addPopperClassesToBody) {
+          document.body.classList.add(`v-popper--some-open--${theme}`)
+        }
       }
 
       this.$emit('apply-show')
@@ -807,13 +817,13 @@ const createPopper = () => defineComponent({
 
       this.skipTransition = skipTransition
       removeFromArray(shownPoppers, this)
-      if (shownPoppers.length === 0) {
+      if (shownPoppers.length === 0 && this.addPopperClassesToBody) {
         document.body.classList.remove('v-popper--some-open')
       }
       for (const theme of getAllParentThemes(this.theme)) {
         const list = getShownPoppersByTheme(theme)
         removeFromArray(list, this)
-        if (list.length === 0) {
+        if (list.length === 0 && this.addPopperClassesToBody) {
           document.body.classList.remove(`v-popper--some-open--${theme}`)
         }
       }

--- a/packages/floating-vue/src/components/PopperWrapper.vue
+++ b/packages/floating-vue/src/components/PopperWrapper.vue
@@ -219,6 +219,12 @@ export default defineComponent({
       default: undefined,
     },
 
+    addPopperClassesToBody: {
+      type: Boolean,
+      default: true,
+    },
+
+
     /**
      * @deprecated
      */

--- a/packages/floating-vue/src/config.ts
+++ b/packages/floating-vue/src/config.ts
@@ -31,6 +31,8 @@ export const config: FloatingVueConfig = {
   arrowPadding: 0,
   // Compute arrow overflow (useful to hide it)
   arrowOverflow: true,
+  // Add popper classes to body, allowing more customization but may affect performance
+  addPopperClassesToBody: true,
   // Themes
   themes: {
     tooltip: {


### PR DESCRIPTION
# Problem
* When a page contains a large number of DOM nodes, toggling floating elements becomes very slow. This happens because `floating-vue` is adding/removing classes directly on `body`, which triggers reflowing that affects a lot of nodes
* This is extremely impactful, especially in analytics application that renders tables with many cells
* I do not see that these added classes are used anywhere so I guess they are either legacy or for customization ability 

* Using the Egdge performance tool, we could see that `$_applyShow` and `$_applyHide` are affecting many elements during the style recalculation phase
![image](https://github.com/Akryum/floating-vue/assets/50204553/99827050-7663-44a2-bfc0-ee6718d2c2e3)
![image](https://github.com/Akryum/floating-vue/assets/50204553/773d4cdc-dba9-43cc-ac6a-f47150642a74)

# Solution
* Added an `addPopperClassesToBody` option to disable the adding-popper-classes-to-body behavior
* Default to true to avoid breaking current behavior