### PR TITLE
docs: fix class table for advanced transitions

### DIFF
--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -210,17 +210,17 @@ Showing:
 | ----- | ------- | ------- |
 | `v-popper__popper--show-from` | **true** | false |
 | `v-popper__popper--show-to` | false | **true** |
-| `v-popper__popper--hidden-from` | false | false |
-| `v-popper__popper--hidden-to` | false | false |
+| `v-popper__popper--hide-from` | false | false |
+| `v-popper__popper--hide-to` | false | false |
 
-Hidding:
+Hiding:
 
 | Class | Frame 1 | Frame 2 |
 | ----- | ------- | ------- |
 | `v-popper__popper--show-from` | false | false |
 | `v-popper__popper--show-to` | false | false |
-| `v-popper__popper--hidden-from` | **true** | false |
-| `v-popper__popper--hidden-to` | false | **true** |
+| `v-popper__popper--hide-from` | **true** | false |
+| `v-popper__popper--hide-to` | false | **true** |
 
 #### Zoom show only example
 

--- a/docs/guide/css.md
+++ b/docs/guide/css.md
@@ -222,6 +222,8 @@ Hiding:
 | `v-popper__popper--hide-from` | **true** | false |
 | `v-popper__popper--hide-to` | false | **true** |
 
+Please note that the default styles for the parent of `.v-popper__wrapper` (i.e. `.v-popper__popper.v-popper__popper--shown` and `.v-popper__popper.v-popper__popper--hidden`) have a transition-duration of .15 seconds. So if your transition of `.v-popper__wrapper` takes longer, you might want to change this transition as well. 
+
 #### Zoom show only example
 
 ```html


### PR DESCRIPTION
Hi 👋

The classes for the hiding transition are wrong in the table in https://floating-vue.starpad.dev/guide/css#advanced-transitions, so I changed them accordingly.

Also, I realized that if you follow the docs and change the transition of `.v-popper__wrapper`, you also have to change the transition of its parent (`.v-popper__popper`). So if your transition takes .5 seconds for example, you wouldn't be able to see the whole transition because of the parent's transition that takes only .15 seconds.

You can see an example of this in this stackblitz: https://stackblitz.com/edit/vue-fyqfc2?file=src%2FApp.vue,src%2Fmain.js

So I added a little note about it. I'm not sure if I explained it well and if it needs to be in the docs, but it probably would have saved me some time.
