### PR TITLE
Add global configuration example to Nuxt installation docs

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -213,3 +213,15 @@ export default defineNuxtConfig({
   ]
 })
 ```
+
+To change global configuration options, you can use a Nuxt plugin:
+
+```js
+// plugins/floating-vue.client.ts
+
+import FloatingVue from 'floating-vue'
+
+export default defineNuxtPlugin(() => {
+    FloatingVue.options.themes.tooltip.placement = 'bottom'
+})
+```


### PR DESCRIPTION
I was expecting to be able to add config options in `nuxt.config.ts` file, e.g. `floatingVue: { placement: 'bottom' }`. 

After seeing [this thread](https://github.com/Akryum/floating-vue/issues/1001), I thought i'd update the documentation to help others.

Thanks for an awesome library.