### PR TITLE
Menu hides when hovering over menu item after hovering over submenu

### DIFF
--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -467,12 +467,12 @@ const createPopper = () => defineComponent({
         if (this.parentPopper) {
           this.parentPopper.lockedChild = this
           clearTimeout(this.parentPopper.lockedChildTimer)
-          this.parentPopper.lockedChildTimer = setTimeout(() => {
-            if (this.parentPopper.lockedChild === this) {
-              this.parentPopper.lockedChild.hide({ skipDelay })
-              this.parentPopper.lockedChild = null
-            }
-          }, 1000)
+          // this.parentPopper.lockedChildTimer = setTimeout(() => {
+          //   if (this.parentPopper.lockedChild !== this) {
+          //     this.parentPopper.lockedChild.hide({ skipDelay })
+          //     this.parentPopper.lockedChild = null
+          //   }
+          // }, 1000)
         }
         return
       }

--- a/packages/floating-vue/src/components/Popper.ts
+++ b/packages/floating-vue/src/components/Popper.ts
@@ -277,6 +277,11 @@ const createPopper = () => defineComponent({
       type: Number,
       default: defaultPropFactory('disposeTimeout'),
     },
+
+    autoCloseTimeout: {
+      type: Number,
+      default: defaultPropFactory('autoCloseTimeout'),
+    },
   },
 
   emits: {
@@ -467,12 +472,14 @@ const createPopper = () => defineComponent({
         if (this.parentPopper) {
           this.parentPopper.lockedChild = this
           clearTimeout(this.parentPopper.lockedChildTimer)
-          // this.parentPopper.lockedChildTimer = setTimeout(() => {
-          //   if (this.parentPopper.lockedChild !== this) {
-          //     this.parentPopper.lockedChild.hide({ skipDelay })
-          //     this.parentPopper.lockedChild = null
-          //   }
-          // }, 1000)
+          if (this.autoCloseTimeout > 0) {
+            this.parentPopper.lockedChildTimer = setTimeout(() => {
+              if (this.parentPopper.lockedChild === this) {
+                this.parentPopper.lockedChild.hide({ skipDelay })
+                this.parentPopper.lockedChild = null
+              }
+            }, this.autoCloseTimeout)
+          }
         }
         return
       }

--- a/packages/floating-vue/src/config.ts
+++ b/packages/floating-vue/src/config.ts
@@ -31,6 +31,8 @@ export const config: FloatingVueConfig = {
   arrowPadding: 0,
   // Compute arrow overflow (useful to hide it)
   arrowOverflow: true,
+  // Timeout that will trigger the closing of parent popper in (ms - 0 means disabled)
+  autoCloseTimeout: 1000,
   /**
    * By default, compute autohide on 'click'.
    */


### PR DESCRIPTION
Is there a reason why the menu would close after a second?

This PR isn't the solution, but I just wanted to get the ball rolling on this.

Added a setting to change the auto-close behavior.

Will increase the 1-second timeout to 2 seconds:
```vue
<VDropdown :autoCloseTimeout="2000">
...
</VDropdown>
```

Will disable the auto-close behavior completely:
```vue
<VDropdown :autoCloseTimeout="0">
...
</VDropdown>
```

Closes #916