### PR TITLE
feat!: move package to ESM only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 npm-debug.log
 coverage/
 dist/
+.idea/

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,9 +15,11 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
+    "@tsconfig/node22": "^22.0.0",
     "@vitejs/plugin-vue": "^5.0.3",
     "@vue/compiler-sfc": "^3.4.13",
     "@vue/eslint-config-standard": "^8.0.1",
+    "@vue/tsconfig": "^0.7.0",
     "autoprefixer": "^10.4.16",
     "babel-eslint": "^10.1.0",
     "eslint": "^8.56.0",
@@ -29,6 +31,10 @@
     "eslint-plugin-vue": "^9.20.1",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.0.11"
+    "unplugin-auto-import": "^19.2.0",
+    "unimport": "^5.0.1",
+    "vite": "^5.0.11",
+    "vue-tsc": "^2.2.10",
+    "typescript": "^5.1.3"
   }
 }

--- a/demo/src/views/directive/VTooltipDemo1.vue
+++ b/demo/src/views/directive/VTooltipDemo1.vue
@@ -1,3 +1,6 @@
+<script lang="ts">
+//
+</script>
 <template>
   <h1>VTooltip Demo 1</h1>
 

--- a/demo/tsconfig.app.json
+++ b/demo/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+
+    "baseUrl": ".",
+    "paths": {
+      "floating-vue/directives": ["../packages/floating-vue/src/directives.ts"],
+      "floating-vue": ["../packages/floating-vue/src/index.ts"]
+    }
+  },
+  "include": ["*.d.ts", "src/**/*", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"]
+}

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "files": []
+}

--- a/demo/tsconfig.node.json
+++ b/demo/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "extends": "@tsconfig/node22/tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+
+    "baseUrl": ".",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "paths": {
+      "floating-vue/directives": ["../packages/floating-vue/src/directives.ts"],
+      "floating-vue": ["../packages/floating-vue/src/index.ts"]
+    },
+    "noEmit": true
+  },
+  "include": [
+    "vite.config.*",
+    "vitest.config.*",
+    "cypress.config.*",
+    "nightwatch.conf.*",
+    "playwright.config.*"
+  ]
+}

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,8 +1,30 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import AutoImport from 'unplugin-auto-import/vite'
+import { FloatingVueDirectives } from 'floating-vue/unimport-presets'
+import { resolve }  from 'node:path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      'floating-vue/style.css': resolve('./node_modules/floating-vue/dist/style.css'),
+      'floating-vue/dist/style.css': resolve('./node_modules/floating-vue/dist/style.css'),
+      'floating-vue/components': resolve('./node_modules/floating-vue/components.mjs'),
+      'floating-vue/directives': resolve('./node_modules/floating-vue/directives.mjs'),
+      'floating-vue': resolve('./node_modules/floating-vue/dist/index.mjs'),
+    }
+  },
+  define: {
+    'VERSION': JSON.stringify('0.0.0'),
+  },
   plugins: [
     vue(),
+      AutoImport({
+        imports: [
+          FloatingVueDirectives(),
+        ],
+        dts: true,
+        vueDirectives: true,
+      })
   ],
 })

--- a/docs/.vitepress/components/theme-editor/ConfigEditor.vue
+++ b/docs/.vitepress/components/theme-editor/ConfigEditor.vue
@@ -1,7 +1,7 @@
 <script>
 import { builtinThemes } from './builtin-themes'
 import { mapState, state } from './state'
-import { SHOW_EVENT_MAP, placements } from 'floating-vue'
+import { SHOW_EVENT_MAP, placements } from 'floating-vue/utils'
 import ToolIcon from '~icons/lucide/wrench'
 import Tabs from './Tabs.vue'
 import { loadValue, storeValue } from './util'

--- a/docs/components.d.ts
+++ b/docs/components.d.ts
@@ -12,7 +12,6 @@ declare module 'vue' {
     DropdownMobileDemo: typeof import('./.vitepress/components/DropdownMobileDemo.vue')['default']
     DropdownPlacement: typeof import('./.vitepress/components/DropdownPlacement.vue')['default']
     DropdownSimpleExample: typeof import('./.vitepress/components/DropdownSimpleExample.vue')['default']
-    DropdownVClodePopperDemo: typeof import('./.vitepress/components/DropdownVClodePopperDemo.vue')['default']
     MenuSimpleExample: typeof import('./.vitepress/components/MenuSimpleExample.vue')['default']
     OffsetExample: typeof import('./.vitepress/components/OffsetExample.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']

--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
   resolve: {
     alias: {
       'floating-vue/style.css': resolve(__dirname, '../packages/floating-vue/dist/style.css'),
+      'floating-vue/utils': resolve(__dirname, '../packages/floating-vue/src/utils.ts'),
       'floating-vue': resolve(__dirname, '../packages/floating-vue/src/index.ts'),
     },
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@akryum/sheep": "^0.5.0",
-    "floating-vue": "workspace:*",
+    "@types/node": "^22.15.17",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "@vue/eslint-config-standard": "^8.0.1",
@@ -24,6 +24,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-vue": "^9.14.1",
+    "floating-vue": "workspace:*",
     "typescript": "^5.1.3"
   }
 }

--- a/packages/floating-vue/components.d.mts
+++ b/packages/floating-vue/components.d.mts
@@ -1,13 +1,12 @@
-export { VDropdown, VMenu, VTooltip } from './dist/components.mjs';
+export { VDropdown, VMenu, VTooltip } from './dist/components.mjs'
+export { Placement } from './dist/utils.mjs'
+export { TriggerEvent } from './dist/components/PopperWrapper.vue.mjs'
+export { hideAllPoppers, recomputeAllPoppers } from './dist/components/Popper.mjs'
 
-export { default as Popper } from './dist/components/Popper.vue.mjs';
-export type * from './dist/components/Popper.vue.d.mts';
-
+export { default as Popper } from './dist/components/Popper.vue.mjs'
 export { default as PopperContent } from './dist/components/PopperContent.vue.mjs'
-export type * from './dist/components/PopperContent.vue.d.mts'
-
+export { default as PopperMethods } from './dist/components/PopperMethods.mjs'
 export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.mjs'
-export type * from './dist/components/PopperWrapper.vue.d.mts'
-
+export { default as ThemeClass } from './dist/components/ThemeClass.mjs'
+export { default as Tooltip } from './dist/components/Tooltip.mjs'
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.mjs'
-export type * from './dist/components/TooltipDirective.vue.d.mts'

--- a/packages/floating-vue/components.d.mts
+++ b/packages/floating-vue/components.d.mts
@@ -10,3 +10,6 @@ export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.mj
 export { default as ThemeClass } from './dist/components/ThemeClass.mjs'
 export { default as Tooltip } from './dist/components/Tooltip.mjs'
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.mjs'
+
+export declare const ComponentNames: readonly ['VDropdown' | 'VMenu' | 'VTooltip' | 'Popper' | 'PopperContent' | 'PopperMethods' | 'PopperWrapper' | 'ThemeClass' | 'Tooltip' | 'TooltipDirective'];
+export type ComponentName = typeof ComponentNames[number];

--- a/packages/floating-vue/components.d.mts
+++ b/packages/floating-vue/components.d.mts
@@ -1,0 +1,13 @@
+export { VDropdown, VMenu, VTooltip } from './dist/components.mjs';
+
+export { default as Popper } from './dist/components/Popper.vue.mjs';
+export type * from './dist/components/Popper.vue.d.mts';
+
+export { default as PopperContent } from './dist/components/PopperContent.vue.mjs'
+export type * from './dist/components/PopperContent.vue.d.mts'
+
+export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.mjs'
+export type * from './dist/components/PopperWrapper.vue.d.mts'
+
+export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.mjs'
+export type * from './dist/components/TooltipDirective.vue.d.mts'

--- a/packages/floating-vue/components.d.ts
+++ b/packages/floating-vue/components.d.ts
@@ -1,0 +1,13 @@
+export { VDropdown, VMenu, VTooltip } from './dist/components';
+
+export { default as Popper } from './dist/components/Popper.vue.js';
+export type * from './dist/components/Popper.vue.d.ts';
+
+export { default as PopperContent } from './dist/components/PopperContent.vue.js'
+export type * from './dist/components/PopperContent.vue.d.ts'
+
+export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.js'
+export type * from './dist/components/PopperWrapper.vue.d.ts'
+
+export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.js'
+export type * from './dist/components/TooltipDirective.vue.d.ts'

--- a/packages/floating-vue/components.d.ts
+++ b/packages/floating-vue/components.d.ts
@@ -1,13 +1,12 @@
-export { VDropdown, VMenu, VTooltip } from './dist/components';
+export { VDropdown, VMenu, VTooltip } from './dist/components'
+export { Placement } from './dist/utils'
+export { TriggerEvent } from './dist/components/PopperWrapper.vue.js'
+export { hideAllPoppers, recomputeAllPoppers } from './dist/components/Popper.js'
 
 export { default as Popper } from './dist/components/Popper.vue.js';
-export type * from './dist/components/Popper.vue.d.ts';
-
 export { default as PopperContent } from './dist/components/PopperContent.vue.js'
-export type * from './dist/components/PopperContent.vue.d.ts'
-
+export { default as PopperMethods } from './dist/components/PopperMethods.js'
 export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.js'
-export type * from './dist/components/PopperWrapper.vue.d.ts'
-
+export { default as ThemeClass } from './dist/components/ThemeClass.js'
+export { default as Tooltip } from './dist/components/Tooltip.js'
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.js'
-export type * from './dist/components/TooltipDirective.vue.d.ts'

--- a/packages/floating-vue/components.d.ts
+++ b/packages/floating-vue/components.d.ts
@@ -10,3 +10,6 @@ export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.js
 export { default as ThemeClass } from './dist/components/ThemeClass.js';
 export { default as Tooltip } from './dist/components/Tooltip.js';
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.js';
+
+export declare const ComponentNames: readonly ['VDropdown' | 'VMenu' | 'VTooltip' | 'Popper' | 'PopperContent' | 'PopperMethods' | 'PopperWrapper' | 'ThemeClass' | 'Tooltip' | 'TooltipDirective'];
+export type ComponentName = typeof ComponentNames[number];

--- a/packages/floating-vue/components.d.ts
+++ b/packages/floating-vue/components.d.ts
@@ -1,12 +1,12 @@
-export { VDropdown, VMenu, VTooltip } from './dist/components'
-export { Placement } from './dist/utils'
-export { TriggerEvent } from './dist/components/PopperWrapper.vue.js'
-export { hideAllPoppers, recomputeAllPoppers } from './dist/components/Popper.js'
+export { VDropdown, VMenu, VTooltip } from './dist/components';
+export { Placement } from './dist/utils';
+export { TriggerEvent } from './dist/components/PopperWrapper.vue.js';
+export { hideAllPoppers, recomputeAllPoppers } from './dist/components/Popper.js';
 
 export { default as Popper } from './dist/components/Popper.vue.js';
-export { default as PopperContent } from './dist/components/PopperContent.vue.js'
-export { default as PopperMethods } from './dist/components/PopperMethods.js'
-export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.js'
-export { default as ThemeClass } from './dist/components/ThemeClass.js'
-export { default as Tooltip } from './dist/components/Tooltip.js'
-export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.js'
+export { default as PopperContent } from './dist/components/PopperContent.vue.js';
+export { default as PopperMethods } from './dist/components/PopperMethods.js';
+export { default as PopperWrapper } from './dist/components/PopperWrapper.vue.js';
+export { default as ThemeClass } from './dist/components/ThemeClass.js';
+export { default as Tooltip } from './dist/components/Tooltip.js';
+export { default as TooltipDirective } from './dist/components/TooltipDirective.vue.js';

--- a/packages/floating-vue/components.js
+++ b/packages/floating-vue/components.js
@@ -1,6 +1,9 @@
-export { VDropdown, VMenu, VTooltip } from './dist/components.js'
+export { VDropdown, VMenu, VTooltip } from './dist/components'
+export { hideAllPoppers, recomputeAllPoppers } from './dist/components/Popper'
 
 export { default as Popper } from './dist/components/Popper.vue'
-export { default as PopperContent } from './dist/components/PopperContent.vue'
+export { default as PopperMethods } from './dist/components/PopperMethods'
 export { default as PopperWrapper } from './dist/components/PopperWrapper.vue'
+export { default as ThemeClass } from './dist/components/ThemeClass'
+export { default as Tooltip } from './dist/components/Tooltip'
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue'

--- a/packages/floating-vue/components.js
+++ b/packages/floating-vue/components.js
@@ -1,0 +1,6 @@
+export { VDropdown, VMenu, VTooltip } from './dist/components.js'
+
+export { default as Popper } from './dist/components/Popper.vue'
+export { default as PopperContent } from './dist/components/PopperContent.vue'
+export { default as PopperWrapper } from './dist/components/PopperWrapper.vue'
+export { default as TooltipDirective } from './dist/components/TooltipDirective.vue'

--- a/packages/floating-vue/components.js
+++ b/packages/floating-vue/components.js
@@ -7,3 +7,5 @@ export { default as PopperWrapper } from './dist/components/PopperWrapper.vue'
 export { default as ThemeClass } from './dist/components/ThemeClass'
 export { default as Tooltip } from './dist/components/Tooltip'
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue'
+
+export const ComponentNames = ['VDropdown', 'VMenu', 'VTooltip', 'Popper', 'PopperContent', 'PopperMethods', 'PopperWrapper', 'ThemeClass', 'Tooltip', 'TooltipDirective']

--- a/packages/floating-vue/components.mjs
+++ b/packages/floating-vue/components.mjs
@@ -1,0 +1,6 @@
+export { VDropdown, VMenu, VTooltip } from './dist/components.mjs'
+
+export { default as Popper } from './dist/components/Popper.vue'
+export { default as PopperContent } from './dist/components/PopperContent.vue'
+export { default as PopperWrapper } from './dist/components/PopperWrapper.vue'
+export { default as TooltipDirective } from './dist/components/TooltipDirective.vue'

--- a/packages/floating-vue/components.mjs
+++ b/packages/floating-vue/components.mjs
@@ -1,6 +1,9 @@
 export { VDropdown, VMenu, VTooltip } from './dist/components.mjs'
+export { hideAllPoppers, recomputeAllPoppers } from './dist/components/Popper.mjs'
 
 export { default as Popper } from './dist/components/Popper.vue'
-export { default as PopperContent } from './dist/components/PopperContent.vue'
+export { default as PopperMethods } from './dist/components/PopperMethods.mjs'
 export { default as PopperWrapper } from './dist/components/PopperWrapper.vue'
+export { default as ThemeClass } from './dist/components/ThemeClass.mjs'
+export { default as Tooltip } from './dist/components/Tooltip.mjs'
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue'

--- a/packages/floating-vue/components.mjs
+++ b/packages/floating-vue/components.mjs
@@ -7,3 +7,5 @@ export { default as PopperWrapper } from './dist/components/PopperWrapper.vue'
 export { default as ThemeClass } from './dist/components/ThemeClass.mjs'
 export { default as Tooltip } from './dist/components/Tooltip.mjs'
 export { default as TooltipDirective } from './dist/components/TooltipDirective.vue'
+
+export const ComponentNames = ['VDropdown', 'VMenu', 'VTooltip', 'Popper', 'PopperContent', 'PopperMethods', 'PopperWrapper', 'ThemeClass', 'Tooltip', 'TooltipDirective']

--- a/packages/floating-vue/directives.d.ts
+++ b/packages/floating-vue/directives.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/directives';

--- a/packages/floating-vue/nuxt-schema.d.ts
+++ b/packages/floating-vue/nuxt-schema.d.ts
@@ -1,0 +1,41 @@
+// only for build, excluded from the package
+declare module '@nuxt/schema' {
+  import type { InlinePreset, UnimportOptions } from 'unimport'
+  export type HookResult = Promise<void> | void
+  export interface ImportPresetWithDeprecation extends InlinePreset {
+  }
+  export interface ImportsOptions extends UnimportOptions {}
+  export interface Component {
+    pascalName: string;
+    kebabName: string;
+    export: string;
+    filePath: string;
+    shortPath: string;
+    chunkName: string;
+    prefetch: boolean;
+    preload: boolean;
+    global?: boolean;
+    island?: boolean;
+    mode?: 'client' | 'server' | 'all';
+    /**
+     * This number allows configuring the behavior of overriding Nuxt components.
+     * If multiple components are provided with the same name, then higher priority
+     * components will be used instead of lower priority components.
+     */
+    priority?: number;
+  }
+  export interface NuxtHooks {
+    'imports:sources': (presets: ImportPresetWithDeprecation[]) => HookResult
+    'components:extend': (components: Component[]) => HookResult
+  }
+  export interface Nuxt {
+    options: {
+      build: {
+        transpile: string[]
+      }
+      css: string[]
+      imports: ImportsOptions
+    }
+    hook: <H extends keyof NuxtHooks>(hook: H, callback: NuxtHooks[H]) => void
+  }
+}

--- a/packages/floating-vue/nuxt.d.mts
+++ b/packages/floating-vue/nuxt.d.mts
@@ -1,0 +1,12 @@
+import type { defineNuxtModule } from '@nuxt/kit'
+import type { FloatingVueDirectivesOptions } from 'floating-vue/directives'
+import type { FloatingVueComponentsOptions } from 'floating-vue/components'
+
+export interface FloatingVueNuxtOptions {
+  directives?: FloatingVueDirectivesOptions
+  components?: FloatingVueComponentsOptions
+}
+
+const _default: ReturnType<typeof defineNuxtModule>
+
+export default _default

--- a/packages/floating-vue/nuxt.d.ts
+++ b/packages/floating-vue/nuxt.d.ts
@@ -1,0 +1,12 @@
+import type { defineNuxtModule } from '@nuxt/kit'
+import type { FloatingVueDirectivesOptions } from 'floating-vue/directives'
+import type { FloatingVueComponentsOptions } from 'floating-vue/components'
+
+export interface FloatingVueNuxtOptions {
+  directives?: FloatingVueDirectivesOptions
+  components?: FloatingVueComponentsOptions
+}
+
+const _default: ReturnType<typeof defineNuxtModule>
+
+export default _default

--- a/packages/floating-vue/nuxt.mjs
+++ b/packages/floating-vue/nuxt.mjs
@@ -1,7 +1,47 @@
-export default async function (_, _nuxt) {
+import {
+  FloatingVueDirectives,
+  enableDirectives,
+  prepareFloatingVueComponents,
+} from 'floating-vue/unimport-presets'
+
+/**
+ * Nuxt module implementation.
+ * @param options {import('./nuxt').FloatingVueNuxtOptions}
+ * @param _nuxt {import('@nuxt/schema').Nuxt}
+ * @returns {Promise<void>}
+ */
+export default async function (options = {}, _nuxt) {
   const { addPluginTemplate } = await import('@nuxt/kit')
 
+  /** @type {import('@nuxt/schema').Nuxt} */
   const nuxt = (this && this.nuxt) || _nuxt
+
+  const imports = nuxt.options.imports
+  imports.addons = enableDirectives(imports.addons)
+
+  nuxt.hook('imports:sources', (sources) => {
+    sources.push(
+      FloatingVueDirectives(options.directives),
+    )
+  })
+
+  nuxt.hook('components:extend', async (registry) => {
+    const c = prepareFloatingVueComponents(options.components)
+    for (const component of c) {
+      registry.push({
+        pascalName: component.pascalName,
+        kebabName: component.kebabName,
+        export: component.export,
+        filePath: component.filePath,
+        shortPath: component.filePath,
+        chunkName: component.kebabName,
+        prefetch: false,
+        preload: false,
+        global: false,
+        mode: 'all',
+      })
+    }
+  })
 
   nuxt.options.css.push('floating-vue/dist/style.css')
 

--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -34,6 +34,10 @@
       "types": "./dist/unimport-presets.d.mts",
       "default": "./dist/unimport-presets.mjs"
     },
+    "./unplugin-vue-components-resolvers": {
+      "types": "./dist/unplugin-vue-components-resolvers.d.mts",
+      "default": "./dist/unplugin-vue-components-resolvers.mjs"
+    },
     "./nuxt": "./nuxt.mjs",
     "./style.css": "./dist/style.css",
     "./dist/style.css": "./dist/style.css"
@@ -44,6 +48,7 @@
     "directives.d.ts",
     "utils.d.ts",
     "unimport-presets.d.ts",
+    "unplugin-vue-components-resolvers.d.ts",
     "*.mjs"
   ],
   "dependencies": {

--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -38,7 +38,10 @@
       "types": "./dist/unplugin-vue-components-resolvers.d.mts",
       "default": "./dist/unplugin-vue-components-resolvers.mjs"
     },
-    "./nuxt": "./nuxt.mjs",
+    "./nuxt": {
+      "types": "./nuxt.d.mts",
+      "default": "./nuxt.mjs"
+    },
     "./style.css": "./dist/style.css",
     "./dist/style.css": "./dist/style.css"
   },
@@ -49,7 +52,9 @@
     "utils.d.ts",
     "unimport-presets.d.ts",
     "unplugin-vue-components-resolvers.d.ts",
-    "*.mjs"
+    "nuxt.mjs",
+    "nuxt.d.ts",
+    "nuxt.d.mts"
   ],
   "dependencies": {
     "@floating-ui/dom": "~1.1.1",

--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -5,19 +5,34 @@
   "author": "Guillaume Chau <guillaume.b.chau@gmail.com>",
   "scripts": {
     "dev": "cross-env NODE_ENV=development vite build --watch",
-    "build": "cross-env NODE_ENV=production vite build && vue-tsc -d --emitDeclarationOnly",
+    "build": "cross-env NODE_ENV=production vite build && vue-tsc -d --emitDeclarationOnly && node ./scripts/patch-build.mjs",
     "prepublishOnly": "pnpm run test && pnpm run build",
     "test": "pnpm run test:unit",
     "test:unit": "peeky run"
   },
-  "main": "dist/floating-vue.umd.js",
-  "module": "dist/floating-vue.mjs",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/floating-vue.umd.js",
-      "import": "./dist/floating-vue.mjs",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./components": {
+      "types": "./components.d.mts",
+      "default": "./components.mjs"
+    },
+    "./directives": {
+      "types": "./dist/directives.d.mts",
+      "default": "./dist/directives.mjs"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.mts",
+      "default": "./dist/utils.mjs"
+    },
+    "./unimport-presets": {
+      "types": "./dist/unimport-presets.d.mts",
+      "default": "./dist/unimport-presets.mjs"
     },
     "./nuxt": "./nuxt.mjs",
     "./style.css": "./dist/style.css",
@@ -25,6 +40,10 @@
   },
   "files": [
     "dist",
+    "components.*",
+    "directives.d.ts",
+    "utils.d.ts",
+    "unimport-presets.d.ts",
     "*.mjs"
   ],
   "dependencies": {
@@ -32,11 +51,19 @@
     "vue-resize": "^2.0.0-alpha.1"
   },
   "peerDependencies": {
-    "vue": "^3.2.0",
-    "@nuxt/kit": "^3.2.0"
+    "@nuxt/kit": "^3.2.0",
+    "unimport": "^4.0.0 || ^5.0.0",
+    "unplugin-vue-components": "^28.5.0",
+    "vue": "^3.2.0"
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {
+      "optional": true
+    },
+    "unimport": {
+      "optional": true
+    },
+    "unplugin-vue-components": {
       "optional": true
     }
   },
@@ -50,6 +77,8 @@
     "babel-jest": "^29.5.0",
     "cross-env": "^7.0.3",
     "fs-extra": "^11.1.1",
+    "unimport": "^5.0.1",
+    "unplugin-vue-components": "^28.5.0",
     "vite": "^4.3.9",
     "vue": "^3.3.4",
     "vue-tsc": "^1.6.5",

--- a/packages/floating-vue/scripts/patch-build.mjs
+++ b/packages/floating-vue/scripts/patch-build.mjs
@@ -122,6 +122,7 @@ async function patchBuild () {
     // unimport presets
     fs.cp(resolve(node, 'types.d.ts'), resolve(node, 'types.d.mts')),
     fs.cp(resolve(dist, 'unimport-presets.d.ts'), resolve(dist, 'unimport-presets.d.mts')),
+    fs.cp(resolve(dist, 'unplugin-vue-components-resolvers.d.ts'), resolve(dist, 'unplugin-vue-components-resolvers.d.mts')),
   ])
   await Promise.all([
     // patch index.d.ts
@@ -139,8 +140,9 @@ async function patchBuild () {
     // utils
     editFile(resolve(dist, 'utils.d.mts'), content => patchFileImports(content)),
     // unimport presets
-    editFile(resolve(dist, 'unimport-presets.d.mts'), content => patchFileImports(content)),
     editFile(resolve(node, 'types.d.mts'), content => patchFileImports(content)),
+    editFile(resolve(dist, 'unimport-presets.d.mts'), content => patchFileImports(content)),
+    editFile(resolve(dist, 'unplugin-vue-components-resolvers.d.mts'), content => patchFileImports(content)),
   ])
 
   await editFile(resolve(dist, 'index.d.mts'), content => replaceLocalImports(content))

--- a/packages/floating-vue/scripts/patch-build.mjs
+++ b/packages/floating-vue/scripts/patch-build.mjs
@@ -54,6 +54,16 @@ function replaceLocalImports (content) {
     })
 }
 
+/**
+ * This script is used to patch the build output of the library.
+ * It does the following:
+ * - Patches all `*.d.ts` files replacing `import('..').Placement` imports to use '../utils'.
+ * - Removes all static CSS imports from the DTS content.
+ * - Generates all the `d.mts` files from the `d.ts` files.
+ * - Patches the `*.d.mts` files to add the `.mjs` extension to all local static and dynamic imports.
+ *
+ * @returns {Promise<void>}
+ */
 async function patchBuild () {
   const root = fileURLToPath(new URL('../', import.meta.url))
   const dist = resolve(root, 'dist')

--- a/packages/floating-vue/scripts/patch-build.mjs
+++ b/packages/floating-vue/scripts/patch-build.mjs
@@ -1,0 +1,139 @@
+import fs from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'path'
+
+patchBuild()
+
+/**
+ * @param content {string}
+ */
+function patchFileImports (content) {
+  // replace all relative imports adding .mjs or .cjs using previous regex
+  // and replacing the last part of the path with .mjs or .cjs
+  return content.replace(/from\s+'(.*)';/g, (match, p1) => {
+    if (!p1.startsWith('.')) {
+      return match
+    }
+    return match.replace(p1, `${p1}.mjs`)
+  })
+}
+
+/**
+ * @param content {string}
+ */
+function patchFile (content) {
+  return content.replace(/';/g, '.mjs\';')
+}
+
+/**
+ * @param path {string}
+ * @param callback {(content: string) => string}
+ */
+async function editFile (path, callback) {
+  const content = await fs.readFile(path, { encoding: 'utf8' })
+  await fs.writeFile(path, callback(content), 'utf-8')
+}
+
+/** @param content {string} */
+function removeCssImports (content) {
+  return content.replace(/import\s+['"]([^'"]+\.css)['"];\s+/g, () => {
+    return ''
+  })
+}
+
+/**
+ * @param content {string}
+ */
+function replaceLocalImports (content) {
+  // replace all relative imports adding .mjs or .cjs using previous regex
+  // and replacing the last part of the path with .mjs or .cjs
+  return patchFileImports(content)
+    .replace(/import\("([^'"]+)"\)/g, (match, p1) => {
+      if (!p1.startsWith('.')) {
+        return match
+      }
+      return match.replace(p1, `${p1}.mjs`)
+    })
+}
+
+async function patchBuild () {
+  const root = fileURLToPath(new URL('../', import.meta.url))
+  const dist = resolve(root, 'dist')
+  const components = resolve(dist, 'components')
+  const directives = resolve(dist, 'directives')
+  const node = resolve(dist, 'node')
+  const util = resolve(dist, 'util')
+  const dtsFiles = await fs.readdir(components)
+  await Promise.all(
+    dtsFiles
+      .filter(f => f.endsWith('.d.ts'))
+      .map((file) => {
+        return editFile(
+          resolve(components, file),
+          content => content
+            .replaceAll('import("..").Placement', 'import("../utils").Placement'),
+        )
+      }),
+  )
+  await Promise.all([
+    // remove static css imports from d.ts files
+    editFile(resolve(dist, 'index.d.ts'), content => removeCssImports(content)),
+    fs.cp(resolve(dist, 'config.d.ts'), resolve(dist, 'config.d.mts')),
+    // vue components
+    // fs.cp(resolve(srcComponents, 'Popper.vue'), resolve(components, 'Popper.vue')),
+    // fs.cp(resolve(srcComponents, 'PopperContent.vue'), resolve(components, 'PopperContent.vue')),
+    // fs.cp(resolve(srcComponents, 'PopperWrapper.vue'), resolve(components, 'PopperWrapper.vue')),
+    // fs.cp(resolve(srcComponents, 'TooltipDirective.vue'), resolve(components, 'TooltipDirective.vue')),
+    // components
+    fs.cp(resolve(dist, 'components.d.ts'), resolve(dist, 'components.d.mts')),
+    fs.cp(resolve(components, 'Dropdown.d.ts'), resolve(components, 'Dropdown.d.mts')),
+    fs.cp(resolve(components, 'Menu.d.ts'), resolve(components, 'Menu.d.mts')),
+    fs.cp(resolve(components, 'Popper.d.ts'), resolve(components, 'Popper.d.mts')),
+    fs.cp(resolve(components, 'PopperMethods.d.ts'), resolve(components, 'PopperMethods.d.mts')),
+    fs.cp(resolve(components, 'ThemeClass.d.ts'), resolve(components, 'ThemeClass.d.mts')),
+    fs.cp(resolve(components, 'Tooltip.d.ts'), resolve(components, 'Tooltip.d.mts')),
+    // .vue.d.ts files
+    fs.cp(resolve(components, 'Popper.vue.d.ts'), resolve(components, 'Popper.vue.d.mts')),
+    fs.cp(resolve(components, 'PopperContent.vue.d.ts'), resolve(components, 'PopperContent.vue.d.mts')),
+    fs.cp(resolve(components, 'PopperWrapper.vue.d.ts'), resolve(components, 'PopperWrapper.vue.d.mts')),
+    fs.cp(resolve(components, 'TooltipDirective.vue.d.ts'), resolve(components, 'TooltipDirective.vue.d.mts')),
+    // directives
+    fs.cp(resolve(dist, 'directives.d.ts'), resolve(dist, 'directives.d.mts')),
+    fs.rm(resolve(directives, 'v-tooltip.spec.d.ts'), { force: true }),
+    fs.cp(resolve(directives, 'v-tooltip.d.ts'), resolve(directives, 'v-tooltip.d.mts')),
+    fs.cp(resolve(directives, 'v-close-popper.d.ts'), resolve(directives, 'v-close-popper.d.mts')),
+    // utils
+    fs.cp(resolve(dist, 'utils.d.ts'), resolve(dist, 'utils.d.mts')),
+    fs.cp(resolve(util, 'assign-deep.d.ts'), resolve(util, 'assign-deep.d.mts')),
+    fs.cp(resolve(util, 'env.d.ts'), resolve(util, 'env.d.mts')),
+    fs.cp(resolve(util, 'events.d.ts'), resolve(util, 'events.d.mts')),
+    fs.cp(resolve(util, 'frame.d.ts'), resolve(util, 'frame.d.mts')),
+    fs.cp(resolve(util, 'lang.d.ts'), resolve(util, 'lang.d.mts')),
+    fs.cp(resolve(util, 'popper.d.ts'), resolve(util, 'popper.d.mts')),
+    // unimport presets
+    fs.cp(resolve(node, 'types.d.ts'), resolve(node, 'types.d.mts')),
+    fs.cp(resolve(dist, 'unimport-presets.d.ts'), resolve(dist, 'unimport-presets.d.mts')),
+  ])
+  // patch directives dts file
+  await Promise.all([
+    // patch index.d.ts
+    fs.cp(resolve(dist, 'index.d.ts'), resolve(dist, 'index.d.mts')),
+    // components
+    editFile(resolve(dist, 'components.d.mts'), content => replaceLocalImports(content)),
+    editFile(resolve(components, 'Dropdown.d.mts'), content => replaceLocalImports(content)),
+    editFile(resolve(components, 'Menu.d.mts'), content => replaceLocalImports(content)),
+    editFile(resolve(components, 'Popper.d.mts'), content => replaceLocalImports(content)),
+    editFile(resolve(components, 'Tooltip.d.mts'), content => replaceLocalImports(content)),
+    editFile(resolve(components, 'Popper.vue.d.mts'), content => replaceLocalImports(content)),
+    editFile(resolve(components, 'PopperWrapper.vue.d.mts'), content => replaceLocalImports(content)),
+    // directives
+    editFile(resolve(dist, 'directives.d.mts'), content => patchFile(content)),
+    // utils
+    editFile(resolve(dist, 'utils.d.mts'), content => patchFile(content)),
+    // unimport presets
+    editFile(resolve(dist, 'unimport-presets.d.mts'), content => patchFile(content)),
+    editFile(resolve(node, 'types.d.mts'), content => patchFile(content)),
+  ])
+
+  await editFile(resolve(dist, 'index.d.mts'), content => replaceLocalImports(content))
+}

--- a/packages/floating-vue/src/components.ts
+++ b/packages/floating-vue/src/components.ts
@@ -1,0 +1,3 @@
+export { default as VDropdown } from './components/Dropdown'
+export { default as VMenu } from './components/Menu'
+export { default as VTooltip } from './components/Tooltip'

--- a/packages/floating-vue/src/components/PopperWrapper.vue
+++ b/packages/floating-vue/src/components/PopperWrapper.vue
@@ -66,7 +66,7 @@ import Popper from './Popper.vue'
 import PopperContent from './PopperContent.vue'
 import PopperMethods from './PopperMethods'
 import ThemeClass from './ThemeClass'
-import type { Placement } from '../util/popper.js'
+import type { Placement } from '../utils'
 
 export type TriggerEvent = 'hover' | 'click' | 'focus' | 'touch'
 

--- a/packages/floating-vue/src/directives.ts
+++ b/packages/floating-vue/src/directives.ts
@@ -2,3 +2,6 @@ import ClosePopper from './directives/v-close-popper'
 import Tooltip from './directives/v-tooltip'
 
 export { ClosePopper, Tooltip }
+
+export const DirectiveNames = ['ClosePopper', 'Tooltip'] as const
+export type DirectiveName = typeof DirectiveNames[number]

--- a/packages/floating-vue/src/directives.ts
+++ b/packages/floating-vue/src/directives.ts
@@ -1,0 +1,4 @@
+import ClosePopper from './directives/v-close-popper'
+import Tooltip from './directives/v-tooltip'
+
+export { ClosePopper, Tooltip }

--- a/packages/floating-vue/src/index.ts
+++ b/packages/floating-vue/src/index.ts
@@ -43,9 +43,8 @@ export const Tooltip = PrivateTooltip
 export const TooltipDirective = PrivateTooltipDirective
 // Utils
 export { hideAllPoppers, recomputeAllPoppers } from './components/Popper'
-export * from './util/events'
-export { placements } from './util/popper'
-export type { Placement } from './util/popper'
+export * from './utils'
+export type { Placement } from './utils'
 // Types
 export type { TriggerEvent } from './components/PopperWrapper.vue'
 

--- a/packages/floating-vue/src/index.ts
+++ b/packages/floating-vue/src/index.ts
@@ -2,14 +2,21 @@ import { assign } from './util/assign-deep'
 import { config, FloatingVueConfig } from './config'
 import 'vue-resize/dist/vue-resize.css'
 import './style.css'
+// Components
+import PrivateDropdown from './components/Dropdown'
+import PrivateMenu from './components/Menu'
+import PrivateTooltip from './components/Tooltip'
+// Directives
+import PrivateVTooltip from './directives/v-tooltip'
+import PrivateVClosePopper from './directives/v-close-popper'
 
 /* Exports */
 
 export const options = config
 export { createTooltip, destroyTooltip } from './directives/v-tooltip'
+export const vClosePopper = PrivateVClosePopper // For <script setup>
 
 /* Vue plugin */
-
 export function install (app, options: FloatingVueConfig = {}) {
   if (app.$_vTooltipInstalled) return
   app.$_vTooltipInstalled = true

--- a/packages/floating-vue/src/index.ts
+++ b/packages/floating-vue/src/index.ts
@@ -2,43 +2,11 @@ import { assign } from './util/assign-deep'
 import { config, FloatingVueConfig } from './config'
 import 'vue-resize/dist/vue-resize.css'
 import './style.css'
-// Components
-import PrivateDropdown from './components/Dropdown'
-import PrivateMenu from './components/Menu'
-import PrivatePopper from './components/Popper'
-import PrivatePopperContent from './components/PopperContent.vue'
-import PrivatePopperMethods from './components/PopperMethods'
-import PrivatePopperWrapper from './components/PopperWrapper.vue'
-import PrivateThemeClass from './components/ThemeClass'
-import PrivateTooltip from './components/Tooltip'
-import PrivateTooltipDirective from './components/TooltipDirective.vue'
-// Directives
-import PrivateVTooltip from './directives/v-tooltip'
-import PrivateVClosePopper from './directives/v-close-popper'
 
 /* Exports */
 
 export const options = config
-// Directive
-export const vTooltip = PrivateVTooltip // For <script setup>
 export { createTooltip, destroyTooltip } from './directives/v-tooltip'
-export const vClosePopper = PrivateVClosePopper // For <script setup>
-// Components
-export const Dropdown = PrivateDropdown
-export const Menu = PrivateMenu
-export const Popper = PrivatePopper
-export const PopperContent = PrivatePopperContent
-export const PopperMethods = PrivatePopperMethods
-export const PopperWrapper = PrivatePopperWrapper
-export const ThemeClass = PrivateThemeClass
-export const Tooltip = PrivateTooltip
-export const TooltipDirective = PrivateTooltipDirective
-// Utils
-export { hideAllPoppers, recomputeAllPoppers } from './components/Popper'
-export * from './utils'
-export type { Placement } from './utils'
-// Types
-export type { TriggerEvent } from './components/PopperWrapper.vue'
 
 /* Vue plugin */
 

--- a/packages/floating-vue/src/index.ts
+++ b/packages/floating-vue/src/index.ts
@@ -2,6 +2,7 @@ import { assign } from './util/assign-deep'
 import { config, FloatingVueConfig } from './config'
 import 'vue-resize/dist/vue-resize.css'
 import './style.css'
+
 // Components
 import PrivateDropdown from './components/Dropdown'
 import PrivateMenu from './components/Menu'
@@ -11,10 +12,8 @@ import PrivateVTooltip from './directives/v-tooltip'
 import PrivateVClosePopper from './directives/v-close-popper'
 
 /* Exports */
-
 export const options = config
 export { createTooltip, destroyTooltip } from './directives/v-tooltip'
-export const vClosePopper = PrivateVClosePopper // For <script setup>
 
 /* Vue plugin */
 export function install (app, options: FloatingVueConfig = {}) {

--- a/packages/floating-vue/src/index.ts
+++ b/packages/floating-vue/src/index.ts
@@ -20,16 +20,8 @@ import PrivateVClosePopper from './directives/v-close-popper'
 
 export const options = config
 // Directive
-/**
- * @deprecated Import `vTooltip` instead.
- */
-export const VTooltip = PrivateVTooltip
 export const vTooltip = PrivateVTooltip // For <script setup>
 export { createTooltip, destroyTooltip } from './directives/v-tooltip'
-/**
- * @deprecated Import `vClosePopper` instead.
- */
-export const VClosePopper = PrivateVClosePopper
 export const vClosePopper = PrivateVClosePopper // For <script setup>
 // Components
 export const Dropdown = PrivateDropdown

--- a/packages/floating-vue/src/node/types.ts
+++ b/packages/floating-vue/src/node/types.ts
@@ -1,0 +1,13 @@
+export type DirectiveName = keyof typeof import('floating-vue/directives')
+
+export interface FloatingVueDirectivesOptions {
+  /**
+     * Prefix FloatingVue directives (to allow use other directives with the same name):
+     * - when prefix set to `true` will use `Vuetify` => `v-floating-vue-<directive>: `v-floating-vue-tooltip`.
+     */
+  prefix?: true
+  /**
+     * Directives to exclude.
+     */
+  exclude?: DirectiveName[]
+}

--- a/packages/floating-vue/src/node/types.ts
+++ b/packages/floating-vue/src/node/types.ts
@@ -1,4 +1,10 @@
+import * as components from 'floating-vue/components'
+import * as directives from 'floating-vue/directives'
+
+export type ComponentName = keyof typeof import('floating-vue/components')
 export type DirectiveName = keyof typeof import('floating-vue/directives')
+export const ComponentNames = Object.keys(components) as ComponentName[]
+export const DirectiveNames = Object.keys(directives) as DirectiveName[]
 
 export interface FloatingVueDirectivesOptions {
   /**
@@ -10,4 +16,16 @@ export interface FloatingVueDirectivesOptions {
    * Directives to exclude.
    */
   exclude?: DirectiveName[]
+}
+
+export interface FloatingVueComponentsOptions {
+  /**
+   * Prefix FloatingVue components (to allow users to use other components with the same name):
+   * - when prefix set to `true` will use `FloatingVue` => `FloatingVue<component>: `FloatingVueTooltip`.
+   */
+  prefix?: true
+  /**
+   * Components to exclude.
+   */
+  exclude?: ComponentName[]
 }

--- a/packages/floating-vue/src/node/types.ts
+++ b/packages/floating-vue/src/node/types.ts
@@ -1,10 +1,5 @@
-import * as components from 'floating-vue/components'
-import * as directives from 'floating-vue/directives'
-
-export type ComponentName = keyof typeof import('floating-vue/components')
-export type DirectiveName = keyof typeof import('floating-vue/directives')
-export const ComponentNames = Object.keys(components) as ComponentName[]
-export const DirectiveNames = Object.keys(directives) as DirectiveName[]
+import type { ComponentName } from 'floating-vue/components'
+import type { DirectiveName } from '../directives'
 
 export interface FloatingVueDirectivesOptions {
   /**

--- a/packages/floating-vue/src/node/types.ts
+++ b/packages/floating-vue/src/node/types.ts
@@ -2,12 +2,12 @@ export type DirectiveName = keyof typeof import('floating-vue/directives')
 
 export interface FloatingVueDirectivesOptions {
   /**
-     * Prefix FloatingVue directives (to allow use other directives with the same name):
-     * - when prefix set to `true` will use `Vuetify` => `v-floating-vue-<directive>: `v-floating-vue-tooltip`.
-     */
+   * Prefix FloatingVue directives (to allow users to use other directives with the same name):
+   * - when prefix set to `true` will use `FloatingVue` => `v-floating-vue-<directive>: `v-floating-vue-tooltip`.
+   */
   prefix?: true
   /**
-     * Directives to exclude.
-     */
+   * Directives to exclude.
+   */
   exclude?: DirectiveName[]
 }

--- a/packages/floating-vue/src/unimport-presets.ts
+++ b/packages/floating-vue/src/unimport-presets.ts
@@ -50,7 +50,7 @@ export interface FloatingVueComponentInfo {
   filePath: string
 }
 
-export async function prepareFloatingVueComponents (options: FloatingVueComponentsOptions = {}) {
+export function prepareFloatingVueComponents (options: FloatingVueComponentsOptions = {}) {
   const { prefix = false, exclude = [] } = options
   const info: FloatingVueComponentInfo[] = []
   for (const component of ComponentNames) {

--- a/packages/floating-vue/src/unimport-presets.ts
+++ b/packages/floating-vue/src/unimport-presets.ts
@@ -1,14 +1,13 @@
 import type { DirectiveName, FloatingVueDirectivesOptions } from './node/types'
 import type { InlinePreset, PresetImport } from 'unimport'
-import * as directives from 'floating-vue/directives'
+import { DirectiveNames } from './node/types'
 
 export type { DirectiveName, FloatingVueDirectivesOptions }
 
 export function FloatingVueDirectives (options: FloatingVueDirectivesOptions = {}) {
   const { exclude, prefix } = options
-  const directivesImports = Array.from(Object.keys(directives)) as DirectiveName[]
 
-  const useDirectives = directivesImports.filter(entry => !exclude || !exclude.includes(entry))
+  const useDirectives = DirectiveNames.filter(entry => !exclude || !exclude.includes(entry))
 
   return {
     from: 'floating-vue/directives',

--- a/packages/floating-vue/src/unimport-presets.ts
+++ b/packages/floating-vue/src/unimport-presets.ts
@@ -1,6 +1,7 @@
-import type { DirectiveName, FloatingVueDirectivesOptions } from './node/types'
+import type { DirectiveName } from './directives'
+import type { FloatingVueDirectivesOptions } from './node/types'
 import type { InlinePreset, PresetImport } from 'unimport'
-import { DirectiveNames } from './node/types'
+import { DirectiveNames } from './directives'
 
 export type { DirectiveName, FloatingVueDirectivesOptions }
 

--- a/packages/floating-vue/src/unimport-presets.ts
+++ b/packages/floating-vue/src/unimport-presets.ts
@@ -1,0 +1,27 @@
+import type { DirectiveName, FloatingVueDirectivesOptions } from './node/types'
+import type { InlinePreset, PresetImport } from 'unimport'
+import * as directives from 'floating-vue/directives'
+
+export type { DirectiveName, FloatingVueDirectivesOptions }
+
+export function FloatingVueDirectives (options: FloatingVueDirectivesOptions = {}) {
+  const { exclude, prefix } = options
+  const directivesImports = Array.from(Object.keys(directives)) as DirectiveName[]
+
+  const useDirectives = directivesImports.filter(entry => !exclude || !exclude.includes(entry))
+
+  return {
+    from: 'floating-vue/directives',
+    meta: {
+      vueDirective: true,
+    },
+    imports: useDirectives.map<PresetImport>((name) => ({
+      name,
+      as: prefix ? `FloatingVue${name}` : undefined,
+      meta: {
+        vueDirective: true,
+        docsUrl: 'https://floating-vue.starpad.dev/guide/directive',
+      },
+    })),
+  } satisfies InlinePreset
+}

--- a/packages/floating-vue/src/unimport-presets.ts
+++ b/packages/floating-vue/src/unimport-presets.ts
@@ -1,7 +1,8 @@
 import type { DirectiveName } from './directives'
-import type { FloatingVueDirectivesOptions } from './node/types'
-import type { InlinePreset, PresetImport } from 'unimport'
+import type { FloatingVueComponentsOptions, FloatingVueDirectivesOptions } from './node/types'
+import type { Addon, AddonsOptions, InlinePreset, PresetImport } from 'unimport'
 import { DirectiveNames } from './directives'
+import { ComponentNames } from 'floating-vue/components'
 
 export type { DirectiveName, FloatingVueDirectivesOptions }
 
@@ -24,4 +25,57 @@ export function FloatingVueDirectives (options: FloatingVueDirectivesOptions = {
       },
     })),
   } satisfies InlinePreset
+}
+
+export function enableDirectives (addons?: AddonsOptions | Addon[]): AddonsOptions {
+  if (!addons) {
+    return { vueDirectives: true }
+  }
+
+  if (Array.isArray(addons)) {
+    return { vueDirectives: true, addons }
+  }
+
+  return {
+    ...addons,
+    vueDirectives: addons.vueDirectives ?? true,
+    addons: addons.addons,
+  }
+}
+
+export interface FloatingVueComponentInfo {
+  pascalName: string
+  kebabName: string
+  export: string
+  filePath: string
+}
+
+export async function prepareFloatingVueComponents (options: FloatingVueComponentsOptions = {}) {
+  const { prefix = false, exclude = [] } = options
+  const info: FloatingVueComponentInfo[] = []
+  for (const component of ComponentNames) {
+    if (exclude.includes(component)) {
+      continue
+    }
+
+    const useName = prefix
+      ? `FloatingVue${component[0] === 'V' ? component.slice(1) : component}`
+      : component
+
+    info.push({
+      pascalName: useName,
+      kebabName: toKebabCase(useName),
+      export: component,
+      filePath: `floating-vue/components`,
+    })
+  }
+
+  return info
+}
+
+function toKebabCase (str: string) {
+  return str
+    .replace(/[^a-z]/gi, '-')
+    .replace(/\B([A-Z])/g, '-$1')
+    .toLowerCase()
 }

--- a/packages/floating-vue/src/unplugin-vue-components-resolvers.ts
+++ b/packages/floating-vue/src/unplugin-vue-components-resolvers.ts
@@ -1,11 +1,12 @@
+import type { DirectiveName } from './directives'
+import type { ComponentName } from 'floating-vue/components'
 import type {
-  DirectiveName,
-  ComponentName,
   FloatingVueDirectivesOptions,
   FloatingVueComponentsOptions,
 } from './node/types'
+import { DirectiveNames } from './directives'
+import { ComponentNames } from 'floating-vue/components'
 import type { ComponentResolver } from 'unplugin-vue-components/types'
-import { ComponentNames, DirectiveNames } from './node/types'
 
 export type { ComponentName, DirectiveName, FloatingVueDirectivesOptions, FloatingVueComponentsOptions }
 
@@ -81,21 +82,21 @@ function createComponentsResolver (
   return {
     type: 'component',
     resolve: async (name) => {
-      let floatingVueName = name
+      let floatingVueName = name as ComponentName
       if (prefix) {
         if (!name.startsWith('FloatingVue')) {
           return undefined
         }
-        floatingVueName = `V${name.slice('FloatingVue'.length)}`
-        if (!ComponentNames.includes(floatingVueName as ComponentName)) {
-          floatingVueName = floatingVueName.slice(1)
+        floatingVueName = `V${name.slice('FloatingVue'.length)}` as ComponentName
+        if (!ComponentNames.includes(floatingVueName)) {
+          floatingVueName = floatingVueName.slice(1) as ComponentName
         }
       }
       if (exclude?.some(e => e === floatingVueName)) {
         return undefined
       }
 
-      if (!ComponentNames.includes(floatingVueName as ComponentName)) {
+      if (!ComponentNames.includes(floatingVueName)) {
         return undefined
       }
       return {
@@ -124,17 +125,17 @@ function createDirectivesResolver (
   return {
     type: 'directive',
     resolve: async (resolvedName) => {
-      let name = resolvedName
+      let name = resolvedName as DirectiveName
       if (prefix) {
         if (!name.startsWith('FloatingVue')) {
           return undefined
         }
-        name = name.slice('FloatingVue'.length)
+        name = name.slice('FloatingVue'.length) as DirectiveName
       }
       if (exclude?.some(e => e === name)) {
         return undefined
       }
-      const directive = DirectiveNames.includes(name as DirectiveName)
+      const directive = DirectiveNames.includes(name)
       if (!directive) {
         return undefined
       }

--- a/packages/floating-vue/src/unplugin-vue-components-resolvers.ts
+++ b/packages/floating-vue/src/unplugin-vue-components-resolvers.ts
@@ -1,0 +1,149 @@
+import type {
+  DirectiveName,
+  ComponentName,
+  FloatingVueDirectivesOptions,
+  FloatingVueComponentsOptions,
+} from './node/types'
+import type { ComponentResolver } from 'unplugin-vue-components/types'
+import { ComponentNames, DirectiveNames } from './node/types'
+
+export type { ComponentName, DirectiveName, FloatingVueDirectivesOptions, FloatingVueComponentsOptions }
+
+export interface FloatingVueResolverOptions {
+  /**
+     * Directives to exclude.
+     */
+  excludeDirectives?: DirectiveName[]
+  /**
+     * Components to exclude.
+     */
+  excludeComponents?: ComponentName[]
+  /**
+     * Prefix components.
+     */
+  prefixComponents?: true
+  /**
+     * Prefix directives.
+     */
+  prefixDirectives?: true
+}
+
+/**
+ * FloatingVue directives and components factory resolver for `unplugin-vue-components`.
+ *
+ * @param options The options for directives and components.
+ */
+export function FloatingVueResolver (options: FloatingVueResolverOptions = {}) {
+  const {
+    excludeDirectives,
+    excludeComponents,
+    prefixComponents,
+    prefixDirectives,
+  } = options
+
+  return {
+    FloatingVueDirectiveResolver: createDirectivesResolver(
+      { exclude: excludeDirectives, prefix: prefixDirectives },
+    ),
+    FloatingVueComponentResolver: createComponentsResolver(
+      { exclude: excludeComponents, prefix: prefixComponents },
+    ),
+  }
+}
+
+/**
+ * FloatingVue directives resolver for `unplugin-vue-components`.
+ *
+ * @param options The directives options.
+ */
+export function FloatingVueDirectiveResolver (options: FloatingVueDirectivesOptions = {}) {
+  return createDirectivesResolver(options)
+}
+
+/**
+ * FloatingVue components resolver for `unplugin-vue-components`.
+ *
+ * @param options The components options.
+ */
+export function FloatingVueComponentResolver (options: FloatingVueComponentsOptions = {}) {
+  return createComponentsResolver(options)
+}
+
+/**
+ * Create a resolver for FloatingVue components.
+ *
+ * @param options The components options.
+ */
+function createComponentsResolver (
+  options: FloatingVueComponentsOptions,
+) {
+  const { exclude, prefix } = options
+  return {
+    type: 'component',
+    resolve: async (name) => {
+      let floatingVueName = name
+      if (prefix) {
+        if (!name.startsWith('FloatingVue')) {
+          return undefined
+        }
+        floatingVueName = `V${name.slice('FloatingVue'.length)}`
+        if (!ComponentNames.includes(floatingVueName as ComponentName)) {
+          floatingVueName = floatingVueName.slice(1)
+        }
+      }
+      if (exclude?.some(e => e === floatingVueName)) {
+        return undefined
+      }
+
+      if (!ComponentNames.includes(floatingVueName as ComponentName)) {
+        return undefined
+      }
+      return {
+        name: floatingVueName,
+        as: prefix ? name : undefined,
+        type: 'component',
+        from: 'floating-vue/components',
+      }
+    },
+  } satisfies ComponentResolver
+}
+
+/**
+ * Create a resolver for FloatingVue directives.
+ *
+ * @param options The directives options.
+ */
+function createDirectivesResolver (
+  options: FloatingVueDirectivesOptions,
+) {
+  const { exclude, prefix } = options
+  // Vue will transform v-<directive> to _resolveDirective('<directive>')
+  // If prefix enabled, Vue will transform v-floating-vue-<directive> to _resolveDirective('floating-vue-<directive>')
+  // unplugin-vue-components will provide the correct import when calling resolve: PascalCase(<directive>)
+  // If prefix enabled, unplugin-vue-components will provide PascalCase(floating-vue-<directive>)
+  return {
+    type: 'directive',
+    resolve: async (resolvedName) => {
+      let name = resolvedName
+      if (prefix) {
+        if (!name.startsWith('FloatingVue')) {
+          return undefined
+        }
+        name = name.slice('FloatingVue'.length)
+      }
+      if (exclude?.some(e => e === name)) {
+        return undefined
+      }
+      const directive = DirectiveNames.includes(name as DirectiveName)
+      if (!directive) {
+        return undefined
+      }
+
+      return {
+        name,
+        as: prefix ? resolvedName : undefined,
+        from: `floating-vue/directives`,
+      }
+    },
+  } satisfies ComponentResolver
+}

--- a/packages/floating-vue/src/utils.ts
+++ b/packages/floating-vue/src/utils.ts
@@ -1,0 +1,7 @@
+export * from './util/assign-deep'
+export * from './util/env'
+export * from './util/events'
+export * from './util/frame'
+export * from './util/lang'
+export { placements } from './util/popper'
+export type { Placement } from './util/popper'

--- a/packages/floating-vue/tsconfig.json
+++ b/packages/floating-vue/tsconfig.json
@@ -22,6 +22,7 @@
   "exclude": [
     "node_modules",
     "dist",
-    "**/*.js"
+    "**/*.js",
+    "src/node/**"
   ]
 }

--- a/packages/floating-vue/unimport-presets.d.ts
+++ b/packages/floating-vue/unimport-presets.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/unimport-presets';

--- a/packages/floating-vue/unplugin-vue-components-resolvers.d.ts
+++ b/packages/floating-vue/unplugin-vue-components-resolvers.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/unplugin-vue-components-resolvers'

--- a/packages/floating-vue/utils.d.ts
+++ b/packages/floating-vue/utils.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/utils';

--- a/packages/floating-vue/vite.config.ts
+++ b/packages/floating-vue/vite.config.ts
@@ -25,12 +25,6 @@ export default defineConfig({
         'floating-vue/directives',
         'floating-vue/components',
       ],
-      output: {
-        globals: {
-          vue: 'Vue',
-          '@floating-ui/dom': 'FloatingUIDOM',
-        },
-      },
     },
   },
   define: {

--- a/packages/floating-vue/vite.config.ts
+++ b/packages/floating-vue/vite.config.ts
@@ -8,13 +8,21 @@ export default defineConfig({
   ],
   build: {
     lib: {
-      entry: resolve(__dirname, './src/index.ts'),
+      entry: [
+        resolve(__dirname, './src/index.ts'),
+        resolve(__dirname, './src/components.ts'),
+        resolve(__dirname, './src/directives.ts'),
+        resolve(__dirname, './src/utils.ts'),
+        resolve(__dirname, './src/unimport-presets.ts'),
+      ],
       name: 'FloatingVue',
     },
     rollupOptions: {
       external: [
         'vue',
         '@floating-ui/dom',
+        'unimport',
+        'floating-vue/directives',
       ],
       output: {
         globals: {

--- a/packages/floating-vue/vite.config.ts
+++ b/packages/floating-vue/vite.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
         resolve(__dirname, './src/directives.ts'),
         resolve(__dirname, './src/utils.ts'),
         resolve(__dirname, './src/unimport-presets.ts'),
+        resolve(__dirname, './src/unplugin-vue-components-resolvers.ts'),
       ],
-      name: 'FloatingVue',
     },
     rollupOptions: {
       external: [
@@ -23,6 +23,7 @@ export default defineConfig({
         '@floating-ui/dom',
         'unimport',
         'floating-vue/directives',
+        'floating-vue/components',
       ],
       output: {
         globals: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@akryum/sheep':
         specifier: ^0.5.0
         version: 0.5.0
+      '@types/node':
+        specifier: ^22.15.17
+        version: 22.15.17
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.11
         version: 5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.42.0)(typescript@5.1.3)
@@ -60,6 +63,9 @@ importers:
         specifier: ^4.2.5
         version: 4.2.5(vue@3.4.13)
     devDependencies:
+      '@tsconfig/node22':
+        specifier: ^22.0.0
+        version: 22.0.0
       '@vitejs/plugin-vue':
         specifier: ^5.0.3
         version: 5.0.3(vite@5.0.11)(vue@3.4.13)
@@ -69,6 +75,9 @@ importers:
       '@vue/eslint-config-standard':
         specifier: ^8.0.1
         version: 8.0.1(@typescript-eslint/parser@5.59.11)(eslint-plugin-vue@9.20.1)(eslint@8.56.0)
+      '@vue/tsconfig':
+        specifier: ^0.7.0
+        version: 0.7.0(typescript@5.1.3)(vue@3.4.13)
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.33)
@@ -102,9 +111,21 @@ importers:
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1
+      typescript:
+        specifier: ^5.1.3
+        version: 5.1.3
+      unimport:
+        specifier: ^5.0.1
+        version: 5.0.1
+      unplugin-auto-import:
+        specifier: ^19.2.0
+        version: 19.2.0
       vite:
         specifier: ^5.0.11
-        version: 5.0.11
+        version: 5.0.11(@types/node@22.15.17)
+      vue-tsc:
+        specifier: ^2.2.10
+        version: 2.2.10(typescript@5.1.3)
 
   docs:
     dependencies:
@@ -156,10 +177,10 @@ importers:
         version: 0.25.1(vue@3.3.4)
       vite:
         specifier: ^4.3.9
-        version: 4.3.9
+        version: 4.3.9(@types/node@22.15.17)
       vitepress:
         specifier: ^1.0.0-rc.36
-        version: 1.0.0-rc.36(@algolia/client-search@4.22.0)(postcss@8.4.24)(search-insights@2.6.0)(typescript@5.1.3)
+        version: 1.0.0-rc.36(@algolia/client-search@4.22.0)(@types/node@22.15.17)(postcss@8.4.24)(search-insights@2.6.0)(typescript@5.1.3)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -184,7 +205,7 @@ importers:
         version: 3.6.1
       '@peeky/test':
         specifier: ^0.14.1
-        version: 0.14.1(eslint@8.56.0)
+        version: 0.14.1(@types/node@22.15.17)(eslint@8.56.0)
       '@vitejs/plugin-vue':
         specifier: ^4.2.3
         version: 4.2.3(vite@4.3.9)(vue@3.3.4)
@@ -200,9 +221,15 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
+      unimport:
+        specifier: ^5.0.1
+        version: 5.0.1
+      unplugin-vue-components:
+        specifier: ^28.5.0
+        version: 28.5.0(@nuxt/kit@3.6.1)(vue@3.3.4)
       vite:
         specifier: ^4.3.9
-        version: 4.3.9
+        version: 4.3.9(@types/node@22.15.17)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -432,14 +459,14 @@ packages:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.22.5:
     resolution: {integrity: sha512-m1EP3lVOPptR+2DwD125gziZNcmoNSHGmJROKoy87loWUQyJaVXDgpmruWqDARZSmtYQ+Dl25okU8+qhVzuykw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@babel/helper-compilation-targets@7.22.5(@babel/core@7.22.5):
@@ -496,7 +523,7 @@ packages:
       '@babel/core': 7.22.5
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.22.5
-      debug: 4.3.4
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
       semver: 6.3.1
@@ -528,14 +555,14 @@ packages:
     resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@babel/helper-module-imports@7.22.5:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@babel/helper-module-transforms@7.22.5:
@@ -558,7 +585,7 @@ packages:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@babel/helper-plugin-utils@7.22.5:
@@ -576,7 +603,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -590,7 +617,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -599,14 +626,14 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@babel/helper-split-export-declaration@7.22.5:
@@ -620,8 +647,16 @@ packages:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-string-parser@7.27.1:
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   /@babel/helper-validator-identifier@7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.27.1:
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-option@7.22.5:
@@ -636,7 +671,7 @@ packages:
       '@babel/helper-function-name': 7.22.5
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -675,6 +710,13 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.5
+
+  /@babel/parser@7.27.2:
+    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.27.1
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==}
@@ -1593,7 +1635,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.5
       '@babel/parser': 7.23.6
       '@babel/types': 7.22.5
-      debug: 4.3.4
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1606,6 +1648,13 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
+
+  /@babel/types@7.27.1:
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2138,7 +2187,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -2184,7 +2233,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.2
-      debug: 4.3.4
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2219,7 +2268,7 @@ packages:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.4
       '@iconify/types': 2.0.0
-      debug: 4.3.4
+      debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 0.4.3
     transitivePeerDependencies:
@@ -2286,7 +2335,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.2.3
+      '@types/node': 22.15.17
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: true
@@ -2296,7 +2345,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
@@ -2314,8 +2363,8 @@ packages:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
     dev: true
 
-  /@jridgewell/sourcemap-codec@1.4.15:
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+  /@jridgewell/sourcemap-codec@1.5.0:
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -2378,7 +2427,7 @@ packages:
       defu: 6.1.2
       hookable: 5.5.3
       pathe: 1.1.1
-      pkg-types: 1.0.3
+      pkg-types: 1.3.1
       postcss-import-resolver: 2.0.0
       std-env: 3.3.3
       ufo: 1.1.2
@@ -2389,7 +2438,7 @@ packages:
       - supports-color
     dev: true
 
-  /@peeky/cli@0.14.2(eslint@8.56.0):
+  /@peeky/cli@0.14.2(@types/node@22.15.17)(eslint@8.56.0):
     resolution: {integrity: sha512-JlNjylnS9fyJ2VIjGx+qLijQcJWcSi6UIQEre03oDK33CoOpTft9R2xgReJJimn9nW1tj0ZK6X72i7XyAZcFAA==}
     hasBin: true
     peerDependencies:
@@ -2399,9 +2448,9 @@ packages:
         optional: true
     dependencies:
       '@antfu/install-pkg': 0.1.1
-      '@peeky/config': 0.14.0
+      '@peeky/config': 0.14.0(@types/node@22.15.17)
       '@peeky/eslint-plugin': 0.14.0(eslint@8.56.0)
-      '@peeky/runner': 0.14.0
+      '@peeky/runner': 0.14.0(@types/node@22.15.17)
       consola: 2.15.3
       local-pkg: 0.4.3
       lodash: 4.17.21
@@ -2421,16 +2470,16 @@ packages:
       - terser
     dev: true
 
-  /@peeky/config@0.14.0:
+  /@peeky/config@0.14.0(@types/node@22.15.17):
     resolution: {integrity: sha512-RNoIp+nkw+dA6axNCEedGRVYdgqOfCuS+Fj0vnJINQj/LT1u/tOPAB7ing05MzsTtWlaRpPRBCrWjVCpqPbNlA==}
     dependencies:
       '@peeky/utils': 0.14.0
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       consola: 2.15.3
       fs-extra: 10.1.0
       nanoid: 4.0.2
       pathe: 0.3.9
-      vite: 3.2.6
+      vite: 3.2.6(@types/node@22.15.17)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -2448,15 +2497,15 @@ packages:
       eslint: 8.56.0
     dev: true
 
-  /@peeky/runner@0.14.0:
+  /@peeky/runner@0.14.0(@types/node@22.15.17):
     resolution: {integrity: sha512-N+jSiaRTgzuh3T64G8+BDS5/549xBRAsVHARiHT40YIR1FArx6eE8vctwmoWtTtaugcbimpeh4h+UWgumzTFCA==}
     dependencies:
-      '@peeky/config': 0.14.0
+      '@peeky/config': 0.14.0(@types/node@22.15.17)
       '@peeky/utils': 0.14.0
       '@types/sinon': 10.0.15
       c8: 7.13.0
       chalk: 5.2.0
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       consola: 2.15.3
       diffable-html: 5.0.0
       expect: 29.5.0
@@ -2476,7 +2525,7 @@ packages:
       slugify: 1.6.6
       source-map-support: 0.5.21
       tinypool: 0.3.1
-      vite: 3.2.6
+      vite: 3.2.6(@types/node@22.15.17)
       vite-node: 0.3.6
     transitivePeerDependencies:
       - '@types/node'
@@ -2488,7 +2537,7 @@ packages:
       - terser
     dev: true
 
-  /@peeky/test@0.14.1(eslint@8.56.0):
+  /@peeky/test@0.14.1(@types/node@22.15.17)(eslint@8.56.0):
     resolution: {integrity: sha512-fUW4bDJgnRsOIP5z+4TGVgZaWbCeJvkSb9F0Xu2fH2kYXxe5HiU5mK6cDQ++SpwnyQXFo7rQD6YjtqE+DYBX7g==}
     hasBin: true
     peerDependencies:
@@ -2497,10 +2546,10 @@ packages:
       '@peeky/server':
         optional: true
     dependencies:
-      '@peeky/cli': 0.14.2(eslint@8.56.0)
-      '@peeky/config': 0.14.0
+      '@peeky/cli': 0.14.2(@types/node@22.15.17)(eslint@8.56.0)
+      '@peeky/config': 0.14.0(@types/node@22.15.17)
       '@peeky/eslint-plugin': 0.14.0(eslint@8.56.0)
-      '@peeky/runner': 0.14.0
+      '@peeky/runner': 0.14.0(@types/node@22.15.17)
     transitivePeerDependencies:
       - '@types/node'
       - encoding
@@ -2688,6 +2737,10 @@ packages:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
 
+  /@tsconfig/node22@22.0.0:
+    resolution: {integrity: sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==}
+    dev: true
+
   /@types/babel__core@7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
@@ -2701,26 +2754,26 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.23.6
-      '@babel/types': 7.22.5
+      '@babel/parser': 7.27.2
+      '@babel/types': 7.27.1
     dev: true
 
   /@types/babel__traverse@7.18.5:
     resolution: {integrity: sha512-enCvTL8m/EHS/zIvJno9nE+ndYPh1/oNFzRYRmtUqJICG2VnCSBzMLW5VN2KCQU91f23tsNKR8v7VJJQMatl7Q==}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
     dev: true
 
   /@types/concat-stream@1.6.1:
     resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 22.15.17
     dev: true
 
   /@types/estree@1.0.5:
@@ -2730,13 +2783,13 @@ packages:
   /@types/form-data@0.0.33:
     resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 22.15.17
     dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 22.15.17
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -2782,8 +2835,10 @@ packages:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
     dev: true
 
-  /@types/node@20.2.3:
-    resolution: {integrity: sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==}
+  /@types/node@22.15.17:
+    resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
+    dependencies:
+      undici-types: 6.21.0
     dev: true
 
   /@types/node@8.10.66:
@@ -2967,7 +3022,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.3.9
+      vite: 4.3.9(@types/node@22.15.17)
       vue: 3.3.4
     dev: true
 
@@ -2978,7 +3033,7 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.11
+      vite: 5.0.11(@types/node@22.15.17)
       vue: 3.4.13(typescript@5.1.3)
     dev: true
 
@@ -2988,10 +3043,20 @@ packages:
       '@volar/source-map': 1.4.1
     dev: true
 
+  /@volar/language-core@2.4.13:
+    resolution: {integrity: sha512-MnQJ7eKchJx5Oz+YdbqyFUk8BN6jasdJv31n/7r6/WwlOOv7qzvot6B66887l2ST3bUW4Mewml54euzpJWA6bg==}
+    dependencies:
+      '@volar/source-map': 2.4.13
+    dev: true
+
   /@volar/source-map@1.4.1:
     resolution: {integrity: sha512-bZ46ad72dsbzuOWPUtJjBXkzSQzzSejuR3CT81+GvTEI2E994D8JPXzM3tl98zyCNnjgs4OkRyliImL1dvJ5BA==}
     dependencies:
       muggle-string: 0.2.2
+    dev: true
+
+  /@volar/source-map@2.4.13:
+    resolution: {integrity: sha512-l/EBcc2FkvHgz2ZxV+OZK3kMSroMr7nN3sZLF2/f6kWW66q8+tEL4giiYyFjt0BcubqJhBt6soYIrAPhg/Yr+Q==}
     dev: true
 
   /@volar/typescript@1.4.1-patch.2(typescript@5.1.3):
@@ -3001,6 +3066,14 @@ packages:
     dependencies:
       '@volar/language-core': 1.4.1
       typescript: 5.1.3
+    dev: true
+
+  /@volar/typescript@2.4.13:
+    resolution: {integrity: sha512-Ukz4xv84swJPupZeoFsQoeJEOm7U9pqsEnaGGgt5ni3SCTa22m8oJP5Nng3Wed7Uw5RBELdLxxORX8YhJPyOgQ==}
+    dependencies:
+      '@volar/language-core': 2.4.13
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
     dev: true
 
   /@volar/vue-language-core@1.6.5:
@@ -3030,10 +3103,10 @@ packages:
   /@vue/compiler-core@3.3.4:
     resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.27.2
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      source-map-js: 1.0.2
+      source-map-js: 1.2.1
 
   /@vue/compiler-core@3.4.13:
     resolution: {integrity: sha512-zGUdmB3j3Irn9z51GXLJ5s0EAHxmsm5/eXl0y6MBaajMeOAaiT4+zaDoxui4Ets98dwIRr8BBaqXXHtHSfm+KA==}
@@ -3043,6 +3116,16 @@ packages:
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.0.2
+
+  /@vue/compiler-core@3.5.13:
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
+    dependencies:
+      '@babel/parser': 7.27.2
+      '@vue/shared': 3.5.13
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+    dev: true
 
   /@vue/compiler-dom@3.3.4:
     resolution: {integrity: sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==}
@@ -3056,6 +3139,13 @@ packages:
       '@vue/compiler-core': 3.4.13
       '@vue/shared': 3.4.13
 
+  /@vue/compiler-dom@3.5.13:
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+    dependencies:
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
+    dev: true
+
   /@vue/compiler-sfc@3.3.4:
     resolution: {integrity: sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==}
     dependencies:
@@ -3066,7 +3156,7 @@ packages:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.5
+      magic-string: 0.30.17
       postcss: 8.4.33
       source-map-js: 1.0.2
 
@@ -3094,6 +3184,13 @@ packages:
     dependencies:
       '@vue/compiler-dom': 3.4.13
       '@vue/shared': 3.4.13
+
+  /@vue/compiler-vue2@2.7.16:
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+    dev: true
 
   /@vue/devtools-api@6.5.1:
     resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
@@ -3126,10 +3223,10 @@ packages:
       eslint-plugin-vue: ^9.2.0
     dependencies:
       eslint: 8.56.0
-      eslint-config-standard: 17.0.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.56.0)
-      eslint-import-resolver-custom-alias: 1.3.2(eslint-plugin-import@2.29.1)
+      eslint-config-standard: 17.0.0(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.56.0)
+      eslint-import-resolver-custom-alias: 1.3.2(eslint-plugin-import@2.27.5)
       eslint-import-resolver-node: 0.3.7
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.59.11)(eslint@8.56.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint@8.56.0)
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
       eslint-plugin-vue: 9.20.1(eslint@8.56.0)
@@ -3161,14 +3258,33 @@ packages:
       - supports-color
     dev: true
 
+  /@vue/language-core@2.2.10(typescript@5.1.3):
+    resolution: {integrity: sha512-+yNoYx6XIKuAO8Mqh1vGytu8jkFEOH5C8iOv3i8Z/65A7x9iAOXA97Q+PqZ3nlm2lxf5rOJuIGI/wDtx/riNYw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@volar/language-core': 2.4.13
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.13
+      alien-signals: 1.0.13
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      typescript: 5.1.3
+    dev: true
+
   /@vue/reactivity-transform@3.3.4:
     resolution: {integrity: sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.27.2
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.5
+      magic-string: 0.30.17
 
   /@vue/reactivity@3.3.4:
     resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
@@ -3230,6 +3346,10 @@ packages:
   /@vue/shared@3.4.13:
     resolution: {integrity: sha512-56crFKLPpzk85WXX1L1c0QzPOuoapWlPVys8eMG8kkRmqdMjWUqK8KpFdE2d7BQA4CEbXwyyHPq6MpFr8H9rcg==}
 
+  /@vue/shared@3.5.13:
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+    dev: true
+
   /@vue/test-utils@1.3.6(vue-template-compiler@2.7.14)(vue@3.3.4):
     resolution: {integrity: sha512-udMmmF1ts3zwxUJEIAj5ziioR900reDrt6C9H3XpWPsLBx2lpHKoA4BTdd9HNIYbkGltWw+JjWJ+5O6QBwiyEw==}
     peerDependencies:
@@ -3241,6 +3361,21 @@ packages:
       pretty: 2.0.0
       vue: 3.3.4
       vue-template-compiler: 2.7.14
+    dev: true
+
+  /@vue/tsconfig@0.7.0(typescript@5.1.3)(vue@3.4.13):
+    resolution: {integrity: sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==}
+    peerDependencies:
+      typescript: 5.x
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vue:
+        optional: true
+    dependencies:
+      typescript: 5.1.3
+      vue: 3.4.13(typescript@5.1.3)
     dev: true
 
   /@vueuse/core@10.7.1(vue@3.4.13):
@@ -3322,6 +3457,14 @@ packages:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
 
+  /acorn-jsx@5.3.2(acorn@8.14.1):
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.14.1
+    dev: true
+
   /acorn-jsx@5.3.2(acorn@8.9.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -3330,8 +3473,8 @@ packages:
       acorn: 8.9.0
     dev: true
 
-  /acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+  /acorn@8.14.1:
+    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -3346,7 +3489,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3377,6 +3520,10 @@ packages:
       '@algolia/requester-common': 4.22.0
       '@algolia/requester-node-http': 4.22.0
       '@algolia/transporter': 4.22.0
+    dev: true
+
+  /alien-signals@1.0.13:
+    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
     dev: true
 
   /ansi-regex@5.0.1:
@@ -3650,7 +3797,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/types': 7.27.1
       '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.5
     dev: true
@@ -3801,16 +3948,16 @@ packages:
   /c12@1.4.2:
     resolution: {integrity: sha512-3IP/MuamSVRVw8W8+CHWAz9gKN4gd+voF2zm/Ln6D25C2RhytEZ1ABbC8MjKr4BR9rhoV1JQ7jJA158LDiTkLg==}
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       defu: 6.1.2
       dotenv: 16.3.1
       giget: 1.1.2
       jiti: 1.21.0
-      mlly: 1.4.0
+      mlly: 1.7.4
       ohash: 1.1.2
       pathe: 1.1.1
       perfect-debounce: 1.0.0
-      pkg-types: 1.0.3
+      pkg-types: 1.3.1
       rc9: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -3901,6 +4048,21 @@ packages:
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
@@ -4009,6 +4171,14 @@ packages:
       kind-of: 3.2.2
     dev: true
 
+  /confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+    dev: true
+
+  /confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+    dev: true
+
   /config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
     dependencies:
@@ -4103,6 +4273,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
+
+  /debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
     dev: true
 
   /deep-is@0.1.4:
@@ -4904,7 +5086,7 @@ packages:
       eslint-plugin-promise: 6.1.1(eslint@8.42.0)
     dev: true
 
-  /eslint-config-standard@17.0.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.56.0):
+  /eslint-config-standard@17.0.0(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.56.0):
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
       eslint: ^8.0.1
@@ -4913,7 +5095,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.56.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.59.11)(eslint@8.56.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint@8.56.0)
       eslint-plugin-n: 15.7.0(eslint@8.56.0)
       eslint-plugin-promise: 6.1.1(eslint@8.56.0)
     dev: true
@@ -4924,16 +5106,6 @@ packages:
       eslint-plugin-import: '>=2.2.0'
     dependencies:
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint@8.42.0)
-      glob-parent: 6.0.2
-      resolve: 1.22.2
-    dev: true
-
-  /eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.29.1):
-    resolution: {integrity: sha512-wBPcZA2k6/IXaT8FsLMyiyVSG6WVEuaYIAbeKLXeGwr523BmeB9lKAAoLJWSqp3txsnU4gpkgD2x1q6K8k0uDQ==}
-    peerDependencies:
-      eslint-plugin-import: '>=2.2.0'
-    dependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.59.11)(eslint@8.56.0)
       glob-parent: 6.0.2
       resolve: 1.22.2
     dev: true
@@ -4982,6 +5154,35 @@ packages:
       '@typescript-eslint/parser': 5.59.11(eslint@8.42.0)(typescript@5.1.3)
       debug: 3.2.7
       eslint: 8.42.0
+      eslint-import-resolver-node: 0.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-node@0.3.7)(eslint@8.56.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.59.11(eslint@8.42.0)(typescript@5.1.3)
+      debug: 3.2.7
+      eslint: 8.56.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
       - supports-color
@@ -5088,6 +5289,39 @@ packages:
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-node@0.3.7)(eslint@8.42.0)
+      has: 1.0.3
+      is-core-module: 2.12.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.2
+      semver: 6.3.0
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.11)(eslint@8.56.0):
+    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.59.11(eslint@8.42.0)(typescript@5.1.3)
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      array.prototype.flatmap: 1.3.1
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.56.0
+      eslint-import-resolver-node: 0.3.7
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-node@0.3.7)(eslint@8.56.0)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -5443,8 +5677,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.9.0
-      acorn-jsx: 5.3.2(acorn@8.9.0)
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -5518,6 +5752,10 @@ packages:
       jest-util: 29.5.0
     dev: true
 
+  /exsolve@1.0.5:
+    resolution: {integrity: sha512-pz5dvkYYKQ1AHVrgOzBKWeP4u4FRb3a6DNK2ucr0OoNwYIU4QWsJ+NM36LLzORT+z845MzKHHhpXiUF5nvQoJg==}
+    dev: true
+
   /extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -5569,6 +5807,17 @@ packages:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
       bser: 2.1.1
+    dev: true
+
+  /fdir@6.4.4(picomatch@4.0.2):
+    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+    dependencies:
+      picomatch: 4.0.2
     dev: true
 
   /file-entry-cache@6.0.1:
@@ -6025,7 +6274,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6290,7 +6539,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.22.5
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.27.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -6336,7 +6585,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.2.3
+      '@types/node': 22.15.17
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6384,7 +6633,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 20.2.3
+      '@types/node': 22.15.17
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -6395,7 +6644,7 @@ packages:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.2.3
+      '@types/node': 22.15.17
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -6424,6 +6673,10 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
+
+  /js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
     dev: true
 
   /js-yaml@3.14.1:
@@ -6526,6 +6779,15 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
+  /local-pkg@1.1.1:
+    resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.7.4
+      pkg-types: 2.1.0
+      quansync: 0.2.10
+    dev: true
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -6580,14 +6842,19 @@ packages:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
     engines: {node: '>=12'}
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
     dev: true
+
+  /magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   /magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -6681,6 +6948,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
@@ -6729,19 +7003,28 @@ packages:
   /mlly@0.5.17:
     resolution: {integrity: sha512-Rn+ai4G+CQXptDFSRNnChEgNr+xAEauYhwRvpPl/UHStTlgkIftplgJRsA2OXPuoUn86K4XAjB26+x5CEvVb6A==}
     dependencies:
-      acorn: 8.9.0
+      acorn: 8.14.1
       pathe: 1.1.1
-      pkg-types: 1.0.3
-      ufo: 1.1.2
+      pkg-types: 1.3.1
+      ufo: 1.6.1
     dev: true
 
   /mlly@1.4.0:
     resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
     dependencies:
-      acorn: 8.9.0
+      acorn: 8.14.1
       pathe: 1.1.1
-      pkg-types: 1.0.3
+      pkg-types: 1.3.1
       ufo: 1.1.2
+    dev: true
+
+  /mlly@1.7.4:
+    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+    dependencies:
+      acorn: 8.14.1
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
     dev: true
 
   /mri@1.2.0:
@@ -6759,6 +7042,10 @@ packages:
 
   /muggle-string@0.2.2:
     resolution: {integrity: sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==}
+    dev: true
+
+  /muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
     dev: true
 
   /mz@2.7.0:
@@ -7020,6 +7307,10 @@ packages:
     resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
     dev: true
 
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
+
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -7062,6 +7353,10 @@ packages:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
     dev: true
 
+  /pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    dev: true
+
   /perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
     dev: true
@@ -7072,6 +7367,11 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
+
+  /picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
     dev: true
 
   /pify@2.3.0:
@@ -7088,8 +7388,24 @@ packages:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.4.0
+      mlly: 1.7.4
       pathe: 1.1.1
+    dev: true
+
+  /pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.4
+      pathe: 2.0.3
+    dev: true
+
+  /pkg-types@2.1.0:
+    resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.5
+      pathe: 2.0.3
     dev: true
 
   /portfinder@1.0.32:
@@ -7252,6 +7568,10 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
+    dev: true
+
+  /quansync@0.2.10:
+    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
     dev: true
 
   /queue-microtask@1.2.3:
@@ -7498,6 +7818,10 @@ packages:
     resolution: {integrity: sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==}
     dev: true
 
+  /scule@1.3.0:
+    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+    dev: true
+
   /search-insights@2.6.0:
     resolution: {integrity: sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==}
     engines: {node: '>=8.16.0'}
@@ -7642,6 +7966,10 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
+  /source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   /source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
@@ -7765,7 +8093,13 @@ packages:
   /strip-literal@1.0.1:
     resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
     dependencies:
-      acorn: 8.9.0
+      acorn: 8.14.1
+    dev: true
+
+  /strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+    dependencies:
+      js-tokens: 9.0.1
     dev: true
 
   /sucrase@3.32.0:
@@ -7950,6 +8284,14 @@ packages:
       any-promise: 1.3.0
     dev: true
 
+  /tinyglobby@0.2.13:
+    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+    dev: true
+
   /tinypool@0.3.1:
     resolution: {integrity: sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==}
     engines: {node: '>=14.0.0'}
@@ -8078,6 +8420,10 @@ packages:
     resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
     dev: true
 
+  /ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+    dev: true
+
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -8090,10 +8436,14 @@ packages:
   /unctx@2.3.1:
     resolution: {integrity: sha512-PhKke8ZYauiqh3FEMVNm7ljvzQiph0Mt3GBRve03IJm7ukfaON2OBK795tLwhbyfzknuRRkW0+Ze+CQUmzOZ+A==}
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.14.1
       estree-walker: 3.0.3
-      magic-string: 0.30.5
+      magic-string: 0.30.17
       unplugin: 1.3.1
+    dev: true
+
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
     dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
@@ -8126,20 +8476,80 @@ packages:
       escape-string-regexp: 5.0.0
       fast-glob: 3.3.2
       local-pkg: 0.4.3
-      magic-string: 0.30.5
-      mlly: 1.4.0
+      magic-string: 0.30.17
+      mlly: 1.7.4
       pathe: 1.1.1
-      pkg-types: 1.0.3
-      scule: 1.0.0
+      pkg-types: 1.3.1
+      scule: 1.3.0
       strip-literal: 1.0.1
       unplugin: 1.3.1
     transitivePeerDependencies:
       - rollup
     dev: true
 
+  /unimport@4.2.0:
+    resolution: {integrity: sha512-mYVtA0nmzrysnYnyb3ALMbByJ+Maosee2+WyE0puXl+Xm2bUwPorPaaeZt0ETfuroPOtG8jj1g/qeFZ6buFnag==}
+    engines: {node: '>=18.12.0'}
+    dependencies:
+      acorn: 8.14.1
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.1.1
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      pkg-types: 2.1.0
+      scule: 1.3.0
+      strip-literal: 3.0.0
+      tinyglobby: 0.2.13
+      unplugin: 2.3.2
+      unplugin-utils: 0.2.4
+    dev: true
+
+  /unimport@5.0.1:
+    resolution: {integrity: sha512-1YWzPj6wYhtwHE+9LxRlyqP4DiRrhGfJxdtH475im8ktyZXO3jHj/3PZ97zDdvkYoovFdi0K4SKl3a7l92v3sQ==}
+    engines: {node: '>=18.12.0'}
+    dependencies:
+      acorn: 8.14.1
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.1.1
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      pkg-types: 2.1.0
+      scule: 1.3.0
+      strip-literal: 3.0.0
+      tinyglobby: 0.2.13
+      unplugin: 2.3.2
+      unplugin-utils: 0.2.4
+    dev: true
+
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+    dev: true
+
+  /unplugin-auto-import@19.2.0:
+    resolution: {integrity: sha512-DGRHg86nUDKEYpny1p2kFZjeLg7kHQmknsPQ8krAshvpeypps7dFxNBsAqhBaxYINjetbgQilF8wbjuZxpdomg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@nuxt/kit': ^3.2.2
+      '@vueuse/core': '*'
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@vueuse/core':
+        optional: true
+    dependencies:
+      local-pkg: 1.1.1
+      magic-string: 0.30.17
+      picomatch: 4.0.2
+      unimport: 4.2.0
+      unplugin: 2.3.2
+      unplugin-utils: 0.2.4
     dev: true
 
   /unplugin-icons@0.16.3:
@@ -8168,6 +8578,14 @@ packages:
       unplugin: 1.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /unplugin-utils@0.2.4:
+    resolution: {integrity: sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==}
+    engines: {node: '>=18.12.0'}
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.2
     dev: true
 
   /unplugin-vue-components@0.25.1(vue@3.3.4):
@@ -8199,13 +8617,49 @@ packages:
       - supports-color
     dev: true
 
+  /unplugin-vue-components@28.5.0(@nuxt/kit@3.6.1)(vue@3.3.4):
+    resolution: {integrity: sha512-o7fMKU/uI8NiP+E0W62zoduuguWqB0obTfHFtbr1AP2uo2lhUPnPttWUE92yesdiYfo9/0hxIrj38FMc1eaySg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@babel/parser': ^7.15.8
+      '@nuxt/kit': ^3.2.2
+      vue: 2 || 3
+    peerDependenciesMeta:
+      '@babel/parser':
+        optional: true
+      '@nuxt/kit':
+        optional: true
+    dependencies:
+      '@nuxt/kit': 3.6.1
+      chokidar: 3.6.0
+      debug: 4.4.0
+      local-pkg: 1.1.1
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      tinyglobby: 0.2.13
+      unplugin: 2.3.2
+      unplugin-utils: 0.2.4
+      vue: 3.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /unplugin@1.3.1:
     resolution: {integrity: sha512-h4uUTIvFBQRxUKS2Wjys6ivoeofGhxzTe2sRWlooyjHXVttcVfV/JiavNd3d4+jty0SVV0dxGw9AkY9MwiaCEw==}
     dependencies:
-      acorn: 8.8.2
-      chokidar: 3.5.3
+      acorn: 8.14.1
+      chokidar: 3.6.0
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.5.0
+    dev: true
+
+  /unplugin@2.3.2:
+    resolution: {integrity: sha512-3n7YA46rROb3zSj8fFxtxC/PqoyvYQ0llwz9wtUPUutr9ig09C8gGo5CWCwHrUzlqC1LLR43kxp5vEIyH1ac1w==}
+    engines: {node: '>=18.12.0'}
+    dependencies:
+      acorn: 8.14.1
+      picomatch: 4.0.2
+      webpack-virtual-modules: 0.6.2
     dev: true
 
   /untyped@1.3.2:
@@ -8218,7 +8672,7 @@ packages:
       defu: 6.1.2
       jiti: 1.21.0
       mri: 1.2.0
-      scule: 1.0.0
+      scule: 1.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8304,7 +8758,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@3.2.6:
+  /vite@3.2.6(@types/node@22.15.17):
     resolution: {integrity: sha512-nTXTxYVvaQNLoW5BQ8PNNQ3lPia57gzsQU/Khv+JvzKPku8kNZL6NMUR/qwXhMG6E+g1idqEPanomJ+VZgixEg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -8329,6 +8783,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 22.15.17
       esbuild: 0.15.18
       postcss: 8.4.33
       resolve: 1.22.8
@@ -8337,7 +8792,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@4.3.9:
+  /vite@4.3.9(@types/node@22.15.17):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -8362,6 +8817,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 22.15.17
       esbuild: 0.17.19
       postcss: 8.4.33
       rollup: 3.23.0
@@ -8369,7 +8825,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.0.11:
+  /vite@5.0.11(@types/node@22.15.17):
     resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -8397,6 +8853,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 22.15.17
       esbuild: 0.19.11
       postcss: 8.4.33
       rollup: 4.9.4
@@ -8404,7 +8861,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitepress@1.0.0-rc.36(@algolia/client-search@4.22.0)(postcss@8.4.24)(search-insights@2.6.0)(typescript@5.1.3):
+  /vitepress@1.0.0-rc.36(@algolia/client-search@4.22.0)(@types/node@22.15.17)(postcss@8.4.24)(search-insights@2.6.0)(typescript@5.1.3):
     resolution: {integrity: sha512-2z4dpM9PplN/yvTifhavOIAazlCR6OJ5PvLoRbc+7LdcFeIlCsuDGENLX4HjMW18jQZF5/j7++PNqdBfeazxUA==}
     hasBin: true
     peerDependencies:
@@ -8430,7 +8887,7 @@ packages:
       shikiji: 0.9.17
       shikiji-core: 0.9.17
       shikiji-transformers: 0.9.17
-      vite: 5.0.11
+      vite: 5.0.11(@types/node@22.15.17)
       vue: 3.4.13(typescript@5.1.3)
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -8458,6 +8915,10 @@ packages:
       - terser
       - typescript
       - universal-cookie
+    dev: true
+
+  /vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
     dev: true
 
   /vue-demi@0.14.6(vue@3.4.13):
@@ -8499,7 +8960,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0
       eslint: 8.56.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -8544,6 +9005,17 @@ packages:
       '@volar/vue-language-core': 1.6.5
       '@volar/vue-typescript': 1.6.5(typescript@5.1.3)
       semver: 7.5.1
+      typescript: 5.1.3
+    dev: true
+
+  /vue-tsc@2.2.10(typescript@5.1.3):
+    resolution: {integrity: sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+    dependencies:
+      '@volar/typescript': 2.4.13
+      '@vue/language-core': 2.2.10(typescript@5.1.3)
       typescript: 5.1.3
     dev: true
 
@@ -8607,6 +9079,10 @@ packages:
 
   /webpack-virtual-modules@0.5.0:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
+    dev: true
+
+  /webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
     dev: true
 
   /whatwg-encoding@2.0.0:


### PR DESCRIPTION
This PR doesn't include type module, we can do it later.

This PR includes:
- move the package to ESM-only: all CJS stuff removed
- add unimport-presets subpackage export for directives: I will also include a new preset to use Nuxt components loaders and some utilities here => this subpackage export can be used also with `unplugin-auto-import`, check the demo playground
- add directives subpackage export
- add components subpackage export
- add utils subpackage export
- add script to patch the build:
  - remove static css imports from `index.d.ts`
  - add `d.mts` variants for modules and vue components
  - fix `d.mts` files with correct `.mjs` imports (static and dynamic imports)

Later I will add also a new `unplugin-vue-components-resolvers` subpackage export to allow use directives and components via `unplugin-vue-components`: 2 new resolvers for directives and components.

For context, check my [unvuetify](https://github.com/userquin/unvuetify-monorepo) monorepo.

TODO:
- [x] remove components from index module
- [x] include vue files in the dist/components (copy them): right now we're "exporting" the components twice
- [ ] move repo to ESM-only (add type module to all package.json)
- [x] add unplugin-vue-components-resolvers
- [ ] add unimport presets for utils (composables)
- [x] add Nuxt components utils to enable directives and register components
- [x] review root components stuff, maybe we only want to export VDropdown, VTooltip and VMenu  components (right now exporting everything).
- [ ] configure the repo correctly, running the demo without some changes doesn't work: include tsconfig.json at root with all the subpackage exports and try to figureout how can we remove the resolve.alias from the playground (check https://github.com/Akryum/floating-vue/pull/1078#discussion_r2084431918)
- [x] remove deprecated entries: directives and components in the index.ts module
- [x] include logic to register directives and component in Nuxt module
- [ ] include all issue about directives, with current unimport preset VSCode and any JetBrains IDE should suggest them
- [ ] add migration guide, should be easy: add also new features to the docs somewhere
- [ ] try using new resolvers and presets in the docs and the playground

<details>
<summary><strong>Migration if using imports:</strong></summary>

```ts
import {
  // Directives
  vTooltip,
  vClosePopper,
  // Components
  VDropdown,
  VTooltip,
  VMenu,
  // Utitlities
  SHOW_EVENT_MAP,
  placements
} from 'floating-vue'
```

to

```ts
// Directives
import { vTooltip, vClosePopper } from 'floating-vue/directives'
// Components
import { VDropdown, VTooltip, VMenu } from 'floating-vue/components'
// Utilities
import { SHOW_EVENT_MAP, placements } from 'floating-vue/utils'
```
</details>

![image](https://github.com/user-attachments/assets/b4923242-ed45-4a3c-83ef-7212f4a78463)


