### PR TITLE
feat: add Nuxt 4 & 5 support

### DIFF
--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "@nuxt/kit": "^3.2.0"
+    "@nuxt/kit": "^3.2.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {

--- a/packages/floating-vue/package.json
+++ b/packages/floating-vue/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "vue": "^3.2.0",
-    "@nuxt/kit": "^3.2.0 || ^4.0.0"
+    "@nuxt/kit": "^3.2.0 || ^4.0.0 || ^5.0.0-0"
   },
   "peerDependenciesMeta": {
     "@nuxt/kit": {


### PR DESCRIPTION
## Problem
  Installing floating-vue in a Nuxt 4 project fails with peer dependency conflict:
  - Nuxt 4 requires `@nuxt/kit@^4.x`
  - floating-vue only declares `@nuxt/kit@^3.2.0` as peer dependency

  ### Workaround (without this PR)
  Add to your Nuxt 4 project's `package.json`:
  ```javascript
  // NPM
  {
    "overrides": {
      "floating-vue": {
        "@nuxt/kit": "^4.0.0"
      }
    }
  },
  // YARN
  {
    "resolution": {
      "floating-vue": {
        "@nuxt/kit": "^4.0.0"
      }
    }
  },
  // PNPM
  {
    "pnpm": {
      "peerDependencyRules": {
        "allowedVersions": {
          "floating-vue>@nuxt/kit": "^4.0.0"
        }
      }
    }
  }
  ```

  ### The fix

  Update @nuxt/kit peer dependency to accept both ^3.2.0 and ^4.0.0.

  The existing implementation is already compatible with Nuxt 4

  > Reference: This follows the same pattern used by https://github.com/vueuse/vueuse/blob/main/packages/nuxt/package.json for dual Nuxt 3/4
  support.